### PR TITLE
Add `$vr-border-width` to _variables.scss

### DIFF
--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -712,6 +712,10 @@ $hr-border-color:             null; // Allows for inherited colors
 $hr-border-width:             var(--#{$prefix}border-width);
 $hr-opacity:                  .25;
 
+// scss-docs-start vr-variables
+$vr-border-width:             var(--#{$prefix}border-width);
+// scss-docs-end vr-variables
+
 $legend-margin-bottom:        .5rem;
 $legend-font-size:            1.5rem;
 $legend-font-weight:          null;


### PR DESCRIPTION
## Summary

`$vr-border-width` was introduced in Bootstrap [v5.3.1](https://github.com/twbs/bootstrap/releases/tag/v5.3.1) via https://github.com/twbs/bootstrap/commit/6a9b9af59e0e279e3fc6eb46a043f9a4eae578fe.

## Motivation

Without this variable, Hugo throws the following error during build:

```sh
Error: error building site: TOCSS: failed to transform "scss/app.scss" (text/x-scss): "./node_modules/bootstrap/scss/helpers/_vr.scss:4:10": Undefined variable: "$vr-border-width".
```

## Remarks

I did not incorporate other relevant changes from Bootstrap v5.3.1 since I'm not familiar with how you like to handle updating the config to new Bootstrap versions (are there any semi-automated comparisons/checks that help in doing this?).

In the [release notes](https://github.com/twbs/bootstrap/releases/tag/v5.3.1) there are at least two more relevant changes listed:

> - Add new `$navbar-dark-icon-color` Sass variable
> - Removed duplicate `$alert` Sass variables

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
