### PR TITLE
Properly localize dates

### DIFF
--- a/layouts/partials/main/date.html
+++ b/layouts/partials/main/date.html
@@ -2,5 +2,5 @@
   Returns formatted date.
   Usage: partial "docs/date" (dict "Date" .Date "Format" .Site.Params.BookDateFormat)
 -->
-{{ $format := default "January 2, 2006" .Format -}}
-{{ return (.Date.Format $format) -}}
+{{ $format := default ":date_long" .Format -}}
+{{ return (.Date | time.Format $format) -}}


### PR DESCRIPTION
## Summary

Matters for non-english content. [`.Format`](https://gohugo.io/functions/format/) does not localize dates while [`time.Format`](https://gohugo.io/functions/dateformat/) does.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
