### PR TITLE
Also add regular pages to `docs` menu sidebar

### DIFF
--- a/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -53,5 +53,13 @@
         </div>
       </li>
     {{ end }}
+    {{ range .RegularPages -}}
+      {{ $active := in $currentPage.RelPermalink .RelPermalink -}}
+      <div class="collapse show" id="section-{{ md5 .Title }}">
+        <ul class="btn-toggle-nav list-unstyled fw-normal pb-1 small">
+          <li><a class="docs-link rounded{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Title }}</a></li>
+        </ul>
+      </div>
+    {{- end }}
   {{ end }}
 </ul>

--- a/layouts/partials/sidebar/auto-default-menu.html
+++ b/layouts/partials/sidebar/auto-default-menu.html
@@ -34,4 +34,10 @@
       {{ end }}
     </ul>
   {{ end }}
+  {{ range .RegularPages -}}
+    {{ $active := in $currentPage.RelPermalink .RelPermalink -}}
+    <ul class="list-unstyled">
+      <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .Permalink }}">{{ .Name }}</a></li>
+    </ul>
+  {{- end }}
 {{ end }}


### PR DESCRIPTION
## Summary

Pages directly below `/content/docs/` like `/content/docs/intro.md` are currently not added to the `docs` menu sidebar when `site.Data.doks.menu.section.auto = true`. This PR fixes this  by adding them below the nested section menu entries.

Note that only two out of four relevant partials are adapted (those for `site.Data.doks.menu.section.auto = true`), the two `manual-*-menu.html` partials (for `site.Data.doks.menu.section.auto = false`) are left as-is for now. They should eventually also be adapted to allow for proper manual entries for non-nested/regular `/docs/` pages.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
