### PR TITLE
Include all pages in search index

### DIFF
--- a/layouts/home.searchindex.json
+++ b/layouts/home.searchindex.json
@@ -1,9 +1,6 @@
-{{- $pages := slice -}}
-{{- with site.Data.doks.indexPages -}}
-  {{- $pages = (where (where site.RegularPages "Type" "in" .) "Params.exclude_search" nil) -}}
-{{- else -}}
-  {{- $pages = where site.RegularPages "Params.exclude_search" nil -}}
-{{- end -}}
+{{- $pages := where site.Pages "Params.exclude_search" "!=" true -}}
+{{- if gt (len site.Data.doks.searchExclKinds) 0 }}{{- $pages = where $pages "Kind" "not in" site.Data.doks.searchExclKinds }}{{ end -}}
+{{- if gt (len site.Data.doks.searchExclKinds) 0 }}{{- $pages = where $pages "Type" "not in" site.Data.doks.searchExclTypes }}{{ end -}}
 
 {{/* Source: https://github.com/frjo/hugo-theme-zen/blob/main/layouts/home.searchindex.json */}}
 {{- $.Scratch.Add "searchindex" slice -}}


### PR DESCRIPTION
## Summary

Include all pages in search index by default and replace the old `Doks` config option `indexPages` with more powerful options:
-  `searchExclKinds`: list of page kinds to exclude from search indexing (e.g. `["home", "taxonomy", "term"]`)
- `searchExclTypes`: list of content types to exclude from search indexing (e.g. `["blog", "docs", "legal", "contributors", "categories"]`)

## Motivation

Sections, taxonomies and terms were not included in the search index before, although they often contain relevant site content.

## ~~Caveats~~

~~Maybe you want to make this configurable by the user, so they can choose whether to include `site.Pages` or only `site.RegularPages` in the search index via an additional config option like `site.Data.doks.indexAllPages` (`true`/`false`). Let me know if I should extend this PR to do so.~~ *Done.*

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
