### PR TITLE
Hide TOC title if TOC is empty

### DIFF
--- a/layouts/partials/private/has-headings.html
+++ b/layouts/partials/private/has-headings.html
@@ -1,0 +1,1 @@
+{{ return (gt (len .Fragments.Headings) 0) }}

--- a/layouts/partials/sidebar/docs-toc-desktop.html
+++ b/layouts/partials/sidebar/docs-toc-desktop.html
@@ -1,8 +1,10 @@
 <div class="page-links">
-  <h3>{{ i18n "on-this-page" }}</h3>
-  {{ if eq site.Data.doks.scrollSpy true -}}
-    {{ .TableOfContents | replaceRE "<nav id=\"TableOfContents\">" "<nav id=\"toc\">" | safeHTML }}
-  {{ else -}}
-    {{ .TableOfContents }}
-  {{ end -}}
+  {{ if partial "private/has-headings.html" . -}}
+    <h3>{{ i18n "on-this-page" }}</h3>
+    {{ if eq site.Data.doks.scrollSpy true -}}
+      {{ .TableOfContents | replaceRE "<nav id=\"TableOfContents\">" "<nav id=\"toc\">" | safeHTML -}}
+    {{- else -}}
+      {{ .TableOfContents -}}
+    {{- end }}
+  {{- end }}
 </div>

--- a/layouts/partials/sidebar/docs-toc-mobile.html
+++ b/layouts/partials/sidebar/docs-toc-mobile.html
@@ -1,4 +1,4 @@
-{{ if and (ne .Params.toc false) (ne .TableOfContents "<nav id=\"TableOfContents\"></nav>") -}}
+{{ if and (ne .Params.toc false) (partial "private/has-headings.html" .) -}}
   <details>
     <summary>On this page</summary>
     <div class="page-links">


### PR DESCRIPTION
## Summary

Hides the table of contents (TOC) title ("On this page" by default) if the TOC is empty, i.e. there are no headings in the current page's content. Relevant for the desktop layout. On the mobile layout, this was already fine (i.e. hidden if empty).

Also introduces a canonical way to check whether a page has headings or not by adding a `private/has-headings` partial. It uses [page fragments](https://gohugo.io/variables/page/#page-fragments) instead of the `ne .TableOfContents "<nav id=\"TableOfContents\"></nav>"` comparison, which seems more natural (and is likely faster; but I didn't actually bechmark).

## Motivation

Aesthetics and clarity.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
