### PR TITLE
Improve language menu styling

### DIFF
--- a/assets/scss/common/_dark.scss
+++ b/assets/scss/common/_dark.scss
@@ -528,6 +528,17 @@ hr.text-black-50 {
 
 .dropdown-menu .dropdown-item {
   color: $body-color-dark;
+  &.untranslated {
+    color: $gray-600;
+    text-decoration: line-through;
+    &:hover {
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='icon icon-tabler icon-tabler-home' width='24' height='24' viewBox='0 0 24 24' stroke-width='2' stroke='%23#{str-slice(inspect($link-color-dark), 2)}' fill='none' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M5 12l-2 0l9 -9l9 9l-2 0' /%3E%3Cpath d='M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7' /%3E%3Cpath d='M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6' /%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 1rem top 0.6rem;
+      background-size: 0.9rem 0.9rem;
+      text-decoration: unset;
+    }
+  }
 }
 
 .dropdown-menu .dropdown-item:hover {
@@ -541,7 +552,7 @@ hr.text-black-50 {
   background: $body-bg-dark;
 }
 
-.doks-navbar .dropdown-item.current,
+.navbar .dropdown-item.current,
 .doks-subnavbar .dropdown-item.current {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23dee2e6' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
   background-repeat: no-repeat;
@@ -582,12 +593,8 @@ table th {
 .table-dark, [data-bs-theme="dark"] table {
   --bs-table-color: inherit;
   --bs-table-bg: $body-bg-dark;
-  
+
   background: $body-bg-dark;
   border-color: $border-dark;
 }
-
-
-
 }
-

--- a/assets/scss/common/_dark.scss
+++ b/assets/scss/common/_dark.scss
@@ -528,9 +528,12 @@ hr.text-black-50 {
 
 .dropdown-menu .dropdown-item {
   color: $body-color-dark;
+
   &.untranslated {
     color: $gray-600;
     text-decoration: line-through;
+
+    &:focus-visible,
     &:hover {
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='icon icon-tabler icon-tabler-home' width='24' height='24' viewBox='0 0 24 24' stroke-width='2' stroke='%23#{str-slice(inspect($link-color-dark), 2)}' fill='none' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M5 12l-2 0l9 -9l9 9l-2 0' /%3E%3Cpath d='M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7' /%3E%3Cpath d='M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6' /%3E%3C/svg%3E");
       background-repeat: no-repeat;

--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -245,27 +245,26 @@ pre {
   margin-right: -0.3125rem;
 }
 
-.dropdown-menu-main .dropdown-item {
-  color: inherit;
-  font-size: $font-size-base;
-  font-weight: 400;
-  text-decoration: none;
+.dropdown-menu .dropdown-item {
+  &.untranslated {
+    color: $gray-600;
+    text-decoration: line-through;
+    &:hover {
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='icon icon-tabler icon-tabler-home' width='24' height='24' viewBox='0 0 24 24' stroke-width='2' stroke='%23#{str-slice(inspect($link-color), 2)}' fill='none' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M5 12l-2 0l9 -9l9 9l-2 0' /%3E%3Cpath d='M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7' /%3E%3Cpath d='M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6' /%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 1rem top 0.6rem;
+      background-size: 0.9rem 0.9rem;
+      text-decoration: unset;
+    }
+  }
 }
 
-.dropdown-menu-main .dropdown-item:hover {
-  background-color: transparent;
-  color: $primary;
+.dropdown-menu .dropdown-item:hover {
+  color: $link-color;
 }
 
-.dropdown-menu-main .dropdown-item.active {
-  color: $primary;
-  font-weight: 400;
-  text-decoration: none;
-  background-color: inherit;
-}
-
-.dropdown-menu-main .dropdown-item.active:hover {
-  background-color: transparent;
+.dropdown-menu span.dropdown-item.current:hover {
+  color: unset;
 }
 
 .clipboard {

--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -245,17 +245,17 @@ pre {
   margin-right: -0.3125rem;
 }
 
-.dropdown-menu .dropdown-item {
-  &.untranslated {
-    color: $gray-600;
-    text-decoration: line-through;
-    &:hover {
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='icon icon-tabler icon-tabler-home' width='24' height='24' viewBox='0 0 24 24' stroke-width='2' stroke='%23#{str-slice(inspect($link-color), 2)}' fill='none' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M5 12l-2 0l9 -9l9 9l-2 0' /%3E%3Cpath d='M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7' /%3E%3Cpath d='M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6' /%3E%3C/svg%3E");
-      background-repeat: no-repeat;
-      background-position: right 1rem top 0.6rem;
-      background-size: 0.9rem 0.9rem;
-      text-decoration: unset;
-    }
+.dropdown-menu .dropdown-item.untranslated {
+  color: $gray-600;
+  text-decoration: line-through;
+
+  &:focus-visible,
+  &:hover {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='icon icon-tabler icon-tabler-home' width='24' height='24' viewBox='0 0 24 24' stroke-width='2' stroke='%23#{str-slice(inspect($link-color), 2)}' fill='none' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M5 12l-2 0l9 -9l9 9l-2 0' /%3E%3Cpath d='M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7' /%3E%3Cpath d='M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6' /%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 1rem top 0.6rem;
+    background-size: 0.9rem 0.9rem;
+    text-decoration: unset;
   }
 }
 

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -159,12 +159,12 @@
               <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-down" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                 <path d="M6 9l6 6l6 -6"></path>
-              </svg>  
+              </svg>
             </span>
           </button>
           <ul class="dropdown-menu dropdown-menu-lg-end me-lg-2 shadow rounded border-0" aria-labelledby="doks-languages">
 
-            <li><a class="dropdown-item current" aria-current="true" href="{{ .RelPermalink }}">{{ .Site.Language.LanguageName }}</a></li>
+            <li><span class="dropdown-item current" aria-current="true" href="{{ .RelPermalink }}">{{ .Site.Language.LanguageName }}</span></li>
 
             <li><hr class="dropdown-divider"></li>
 
@@ -175,7 +175,7 @@
             {{ else -}}
               {{ range .Site.Languages -}}
                 {{ if ne $.Site.Language.Lang .Lang }}
-                  <li><a class="dropdown-item" rel="alternate" href="{{ .Lang | relLangURL }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
+                  <li><a class="dropdown-item untranslated" rel="alternate" href="{{ .Lang | relLangURL }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
                 {{ end -}}
               {{ end -}}
             {{ end -}}
@@ -197,7 +197,7 @@
               <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-down" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                 <path d="M6 9l6 6l6 -6"></path>
-              </svg>  
+              </svg>
             </span>
           </button>
           <ul class="dropdown-menu dropdown-menu-lg-end me-lg-2 shadow rounded border-0" aria-labelledby="doks-versions">
@@ -223,7 +223,7 @@
             <path d="M12 12m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0m-5 0h1m8 -9v1m8 8h1m-9 8v1m-6.4 -15.4l.7 .7m12.1 -.7l-.7 .7m0 11.4l.7 .7m-12.1 -.7l-.7 .7"></path>
           </svg>
         </button>
-        {{ end -}}  
+        {{ end -}}
 
         <!-- Social menu -->
         {{ if .Site.Menus.social -}}


### PR DESCRIPTION
## Summary

- Visually distinguishes missing translations.
- Disables link to current language/self (which was pointless and rather confusing).
- Fixes current language indicator (✔) color in dark theme.

## Basic example

On a page in `de` only, from a site with languages `de`, `en`, `fr` and `it`, the language menu looked like this...

[before.webm](https://github.com/gethyas/doks-core/assets/20040931/8c7b6a86-7e8d-48e1-ab30-2322c23295f8)

[after.webm](https://github.com/gethyas/doks-core/assets/20040931/5d56327f-b75d-4e11-b6ed-87f8c530faf2)

## Motivation

UX improvement.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
