### PR TITLE
Add margin below (un)ordered lists

### DIFF
--- a/assets/scss/layouts/_pages.scss
+++ b/assets/scss/layouts/_pages.scss
@@ -7,6 +7,11 @@
   content: "";
 }
 
+.docs-content ul,
+.docs-content ol {
+  margin-bottom: 1rem;
+}
+
 .anchor {
   visibility: hidden;
   margin-left: 0.375rem;


### PR DESCRIPTION
## Summary

Adds the missing margin below (un)ordered lists that are nested below other  (un)ordered lists.

## Basic example

Example Markdown page content where this matters:

```md
1. One

2. Two

   - Step
   - Another step

   This line lacked spacing from the above `<ul>` before this PR!
```

## Motivation

Aesthetics and readability.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
