### PR TITLE
Improve listing of untranslated languages

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -159,7 +159,7 @@
               <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-down" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                 <path d="M6 9l6 6l6 -6"></path>
-              </svg>  
+              </svg>
             </span>
           </button>
           <ul class="dropdown-menu dropdown-menu-lg-end me-lg-2 shadow rounded border-0" aria-labelledby="doks-languages">
@@ -168,17 +168,22 @@
 
             <li><hr class="dropdown-divider"></li>
 
-            {{ if .IsTranslated -}}
-              {{ range .Translations }}
-                <li><a class="dropdown-item" rel="alternate" href="{{ .RelPermalink }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .Language.LanguageName }}</a></li>
-              {{ end -}}
+            {{ if site.Data.doks.showMissingLanguages -}}
+              {{ $translatedLangs := slice -}}
+              {{ range .Translations -}}
+                {{ $translatedLangs = $translatedLangs | append .Lang }}
+              {{- end }}
+              {{ range site.Languages -}}
+                {{ if and (ne $.Lang .Lang) (not (in $.Params.skipTranslations .Lang)) -}}
+                  {{ $isTranslated := in $translatedLangs .Lang -}}
+                  <li><a class="dropdown-item {{ if not $isTranslated }}untranslated{{ end }}" rel="alternate" href="{{ if $isTranslated }}{{ (index (where $.Translations "Lang" .Lang) 0).RelPermalink }}{{ else }}{{ .Lang | relURL }}{{ end }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
+                {{- end }}
+              {{- end }}
             {{ else -}}
-              {{ range .Site.Languages -}}
-                {{ if ne $.Site.Language.Lang .Lang }}
-                  <li><a class="dropdown-item" rel="alternate" href="{{ .Lang | relLangURL }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
-                {{ end -}}
-              {{ end -}}
-            {{ end -}}
+              {{ range .Translations -}}
+                <li><a class="dropdown-item" rel="alternate" href="{{ .RelPermalink }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .Language.LanguageName }}</a></li>
+              {{- end }}
+            {{- end }}
               <!--
               <li><hr class="dropdown-divider"></li>
               <li><a class="dropdown-item" href="/docs/contributing/how-to-contribute/">Help Translate</a></li>
@@ -197,7 +202,7 @@
               <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-down" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                 <path d="M6 9l6 6l6 -6"></path>
-              </svg>  
+              </svg>
             </span>
           </button>
           <ul class="dropdown-menu dropdown-menu-lg-end me-lg-2 shadow rounded border-0" aria-labelledby="doks-versions">
@@ -223,7 +228,7 @@
             <path d="M12 12m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0m-5 0h1m8 -9v1m8 8h1m-9 8v1m-6.4 -15.4l.7 .7m12.1 -.7l-.7 .7m0 11.4l.7 .7m-12.1 -.7l-.7 .7"></path>
           </svg>
         </button>
-        {{ end -}}  
+        {{ end -}}
 
         <!-- Social menu -->
         {{ if .Site.Menus.social -}}


### PR DESCRIPTION
## Summary

Introduces a new Doks config option `showMissingLanguages`. If `true`, an untranslated language is shown in the language menu unless it is listed in the current page's `skipTranslations` param (array/slice).

Before this PR, untranslated languages were always shown if a page was completely untranslated, but not anymore if there was at least one translation.

Related to https://github.com/gethyas/doks-core/pull/37.

## Motivation

Correctness and freedom of choice.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
