### PR TITLE
Add partial for custom script-footer

### DIFF
--- a/layouts/partials/footer/script-footer-custom.html
+++ b/layouts/partials/footer/script-footer-custom.html
@@ -1,4 +1,4 @@
-{{ partial "footer/esbuild" (dict "src" "js/app.js" "targetPath" "main.js" "load" "async" "transpile" false) -}}
+{{/* Put your custom <script> tags here */}}
 
 {{/* EXAMPLE - only load script for production
 {{ if eq (hugo.Environment) "production" -}}

--- a/layouts/partials/footer/script-footer-custom.html
+++ b/layouts/partials/footer/script-footer-custom.html
@@ -1,4 +1,4 @@
-{{/* Put your custom <script> tags here */}}
+{{/* Put your custom <script></script> tags here */}}
 
 {{/* EXAMPLE - only load script for production
 {{ if eq (hugo.Environment) "production" -}}

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -1,8 +1,11 @@
 {{ $bootstrapJavascript := site.Data.doks.bootstrapJavascript -}}
 {{ if $bootstrapJavascript -}}
   {{ partial "footer/esbuild" (dict "src" "js/bootstrap.js" "load" "async" "transpile" false) -}}
-{{ end -}}
-{{ partial "footer/script-footer-core.html" . -}}
+{{- end }}
+
+{{ partial "footer/esbuild" (dict "src" "js/app.js" "targetPath" "main.js" "load" "async" "transpile" false) -}}
+
+{{ partial "footer/script-footer-custom.html" . -}}
 
 {{ partial "main/showFlexSearch" . -}}
 {{ $showFlexSearch := .Scratch.Get "showFlexSearch" -}}


### PR DESCRIPTION
## Summary

Adds a dedicated partial `layouts/partial/footer/script-footer-custom.html` where users can put their custom `<script>` tags. The content of the former `layouts/partial/footer/script-footer-core.html` partial was moved to `layouts/partial/footer/script-footer.html`.

## Motivation

This is a cleaner approach for users to add their custom JS assets since no default template code has to be overwritten (matters in case a future update to Doks brings changes to default template code).

NOTE: This new partial should be documented for future users!

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
