### PR TITLE
Use proper font in GoAT diagrams

### DIFF
--- a/layouts/_default/_markup/render-codeblock-goat.html
+++ b/layouts/_default/_markup/render-codeblock-goat.html
@@ -1,0 +1,18 @@
+{{ $width := .Attributes.width }}
+{{ $height := .Attributes.height }}
+{{ $class := .Attributes.class | default "" }}
+<div class="goat svg-container {{ $class }}">
+  {{ with diagrams.Goat .Inner }}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      font-family="'Jost', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'"
+      {{ if or $width $height }}
+        {{ with $width }}width="{{ . }}"{{ end }}
+        {{ with $height }}height="{{ . }}"{{ end }}
+      {{ else }}
+        viewBox="0 0 {{ .Width }} {{ .Height }}"
+      {{ end }}>
+      {{ .Inner }}
+    </svg>
+  {{ end }}
+</div>


### PR DESCRIPTION
## Summary

Font is hardcoded in [Hugo's default `goat` code block render hook](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/_markup/render-codeblock-goat.html), thus we include a modifed version that uses Doks' default fonts.

## Basic example

````
```goat
      .               .                .               .--- 1          .-- 1     / 1
     / \              |                |           .---+            .-+         +
    /   \         .---+---.         .--+--.        |   '--- 2      |   '-- 2   / \ 2
   +     +        |       |        |       |    ---+            ---+          +
  / \   / \     .-+-.   .-+-.     .+.     .+.      |   .--- 3      |   .-- 3   \ / 3
 /   \ /   \    |   |   |   |    |   |   |   |     '---+            '-+         +
 1   2 3   4    1   2   3   4    1   2   3   4         '--- 4          '-- 4     \ 4

```
````

## Motivation

Aesthetics

## To do

[GoAT diagrams](https://gohugo.io/content-management/diagrams/#goat-diagrams-ascii) are awesome, I think they should be mentioned in Doks' documentation.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
