### PR TITLE
Fix link to home for multilingual sites

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -18,7 +18,7 @@
   {{ end -}}
 
     <!-- Site title -->
-    <a class="navbar-brand me-auto me-lg-3" href="{{ "/" | absURL }}">{{ .Site.Title }}</a>
+    <a class="navbar-brand me-auto me-lg-3" href="{{ "/" | relLangURL }}">{{ .Site.Title }}</a>
 
     <!-- FlexSearch mobile -->
     {{ partial "main/showFlexSearch" . }}


### PR DESCRIPTION
## Summary

Uses a language-specific relative URL as link target of the brand logo in the nav bar instead an absolute URL to `/`.

## Motivation

With this change users aren't inadvertently redirected to the default language.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
