### PR TITLE
Make more strings translatable

### DIFF
--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -10,7 +10,7 @@
       </div>
       <div class="col-lg-8 text-center text-lg-end">
         <ul class="list-inline">
-          <li class="list-inline-item">{{ site.Data.doks.footer | safeHTML }}</li>
+          <li class="list-inline-item">{{ site.Params.footer | safeHTML }}</li>
         </ul>
       </div>
     </div>

--- a/layouts/partials/header/alert.html
+++ b/layouts/partials/header/alert.html
@@ -1,10 +1,10 @@
 {{ if site.Data.doks.alertDismissable -}}
-  <div id="announcement" data-id="global-alert-{{ md5 site.Data.doks.alertText }}" class="alert alert-primary alert-dismissible fade show text-center" role="alert">
-    <span class="alert-text">{{ site.Data.doks.alertText | safeHTML }}</span>
+  <div id="announcement" data-id="global-alert-{{ md5 site.Params.alertText }}" class="alert alert-primary alert-dismissible fade show text-center" role="alert">
+    <span class="alert-text">{{ site.Params.alertText | safeHTML }}</span>
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>
 {{ else -}}
   <div class="alert alert-primary text-center" role="alert">
-    {{ site.Data.doks.alertText | safeHTML }}
+    {{ site.Params.alertText | safeHTML }}
   </div>
 {{ end -}}

--- a/layouts/partials/main/docs-navigation.html
+++ b/layouts/partials/main/docs-navigation.html
@@ -14,7 +14,7 @@
 				 	</svg>
 				</div>
 				<div class="d-flex flex-column">
-					<div class="text-body-secondary">Prev</div>
+					<div class="text-body-secondary">{{ i18n "chapter_previous" }}</div>
 					<a href="{{ .RelPermalink }}" class="stretched-link text-reset text-decoration-none">{{ .Title }}</a>
 				</div>
 			</div>
@@ -27,7 +27,7 @@
 		<div class="card text-end w-100">
 			<div class="card-body d-flex justify-content-end">
 				<div class="d-flex flex-column">
-					<div class="text-body-secondary">Next</div>
+					<div class="text-body-secondary">{{ i18n "chapter_next" }}</div>
 					<a href="{{ .RelPermalink }}" class="stretched-link text-reset text-decoration-none">{{ .Title }}</a>
 				</div>
 				<div class="d-flex flex-column justify-content-center">

--- a/layouts/partials/main/edit-page.html
+++ b/layouts/partials/main/edit-page.html
@@ -34,6 +34,6 @@
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-edit-2">
       <path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path>
     </svg>
-    Edit this page on {{ site.Data.doks.repoHost }}
+    {{ i18n "edit_page" }} {{ site.Data.doks.repoHost }}
   </a>
 </div>

--- a/layouts/partials/main/last-modified.html
+++ b/layouts/partials/main/last-modified.html
@@ -4,7 +4,7 @@
   <div class="last-modified">
     <a href="{{ site.Data.doks.docsRepo }}/{{ $commitPath }}/{{ .GitInfo.Hash }}">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-calendar"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
-      Last modified on {{ $date }}
+      {{ i18n "last_updated" }} {{ $date }}
     </a>
   </div>
 {{ end -}}


### PR DESCRIPTION
## Summary

Makes more stuff translatable:

- Footer and global alert texts, fixes https://github.com/gethyas/doks-core/issues/25.
- "Edit this page" and "Last modified on" link texts, fixes https://github.com/gethyas/doks-core/issues/27.
- Next/previous chapter button texts.

See https://github.com/gethyas/create-hyas/pull/21 for the accompanying config.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
