### PR TITLE
Make head more resilient to missing partials

### DIFF
--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -4,21 +4,25 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{ if templates.Exists "partials/head/resource-hints.html" -}}
     {{ partial "head/resource-hints" . }}
-  {{ end -}}
+  {{- end }}
   {{ if templates.Exists "partials/head/script-header-priority.html" -}}
     {{ partial "head/script-header-priority" . }}
-  {{ end -}}
-  {{ partialCached "head/stylesheet" . }}
+  {{- end }}
+  {{ if templates.Exists "partials/head/stylesheet.html" -}}
+    {{ partialCached "head/stylesheet" . }}
+  {{- end }}
   {{ if templates.Exists "partials/head/seo.html" -}}
     {{ partial "head/seo" . }}
-  {{ else -}}
+  {{- else if templates.Exists "partials/head/seo-default.html" -}}
     {{ partial "head/seo-default" . }}
-  {{ end -}}
-  {{ partial "head/favicons" . }}
+  {{- end }}
+  {{ if templates.Exists "partials/head/favicons.html" -}}
+    {{ partial "head/favicons" . }}
+  {{- end }}
   {{ if templates.Exists "partials/head/script-header.html" -}}
     {{ partial "head/script-header" . }}
-  {{ end -}}
+  {{- end }}
   {{ if templates.Exists "partials/head/custom-head.html" -}}
     {{ partial "head/custom-head" . }}
-  {{ end -}}
+  {{- end }}
 </head>


### PR DESCRIPTION
## Summary

Make the `head/head` partial more resilient against missing other partials. Plus fix whitespace trimming in Go-template syntax.

## Motivation

Resilience and versatility.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
