### PR TITLE
Adds full-width support

### DIFF
--- a/assets/scss/layouts/_pages.scss
+++ b/assets/scss/layouts/_pages.scss
@@ -236,3 +236,11 @@ ul.list-star li {
     border: 1px solid hsl(224deg, 6%, 56%);
   }
 }
+
+.container-fw {
+  max-width: 1200px;
+
+  .docs-toc {
+    margin-left: 3rem;
+  }
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,9 @@
     {{ partial "header/header" . }}
     <div class="wrap container-{{ site.Data.doks.containerBreakpoint | default "lg" }}" role="document">
       <div class="content">
+      {{ if and (eq site.Data.doks.containerBreakpoint "fluid") (or (not (in .Site.Params.mainSections .Type)) (.IsNode)) }}<div class="container p-0">{{ end }}
         {{ block "main" . }}{{ end }}
+      {{ if and (eq site.Data.doks.containerBreakpoint "fluid") (or (not (in .Site.Params.mainSections .Type)) (.IsNode)) }}</div>{{ end }}
       </div>
     </div>
     {{ block "sidebar-prefooter" . }}{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,14 +7,16 @@
 			</nav>
 		</div>
 		{{ end -}}
-		
+		{{ if and (eq site.Data.doks.containerBreakpoint "fluid") (in .Site.Params.mainSections .Type) }}
+			<div class="col container-fw d-flex flex-row justify-content-center mx-auto">
+		{{ end }}
 		{{ if ne .Params.toc false -}}
 		<nav class="docs-toc{{ if ne site.Data.doks.navbarSticky true }} docs-toc-top{{ end }}{{ if site.Data.doks.headerBar }} docs-toc-offset{{ end }} d-none d-xl-block col-xl-3" aria-label="Secondary navigation">
 			{{ partial "sidebar/docs-toc-desktop.html" . }}
 		</nav>
 		{{ end -}}
 		{{ if .Params.toc -}}
-		<main class="docs-content col-lg-11 col-xl{{ if ne site.Data.doks.containerBreakpoint "fluid" }}-9{{ end }}">
+		<main class="docs-content col-lg-11 col-xl-9">
 		{{ else -}}
 		<main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
 		{{ end -}}
@@ -57,5 +59,8 @@
 			{{ end -}}
 			-->
 		</main>
+		{{ if and (eq site.Data.doks.containerBreakpoint "fluid") (in .Site.Params.mainSections .Type) }}
+			</div>
+		{{ end }}
 	</div>
 {{ end }}


### PR DESCRIPTION
## Summary

Adds full-width page support (for all pages) with a global setting:

- In `config/_default/hyas/doks.toml` set `containerBreakpoint = "fluid"`

## Basic example

![Snag_8f60da6](https://github.com/gethyas/doks-core/assets/3902872/da5f24d5-8d12-4a23-92e5-cf2f9ca91eb1)

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

- https://github.com/h-enk/doks/issues/1091

## Future improvements

When you create a docs-based tree (e.g. `npm run create -- --kind docs guides`), you have to add the newly created section (in addition to docs) to `config/_default/params.yml` by setting `mainSections: [docs, guides]`.

This is because of how `layouts/_default/single.html` is set up currently. An improvement would be to have the logic only in `layouts/_default/baseof.html`

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
