### PR TITLE
refactor: added translations

### DIFF
--- a/layouts/partials/main/blog-meta.html
+++ b/layouts/partials/main/blog-meta.html
@@ -1,5 +1,9 @@
 {{ $last := sub (len .Params.contributors) 1 }}
-<p><small>{{ .PublishDate.Format "January 2, 2006" }}{{ if .Params.categories -}}&nbsp;in&nbsp;{{ range $index, $category := .Params.categories -}}{{ if gt $index 0 -}}, {{ end -}}<a class="stretched-link position-relative link-muted" href="{{ "/categories/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end -}}{{ end -}}
+<p><small> {{ if $.Site.Params.dateFormat }}
+  {{ .PublishDate | time.Format .Site.Params.dateFormat }}
+  {{ else }}
+  {{ .PublishDate.Format "January 2, 2006" }}
+  {{ end }}{{ if .Params.categories -}}&nbsp;in&nbsp;{{ range $index, $category := .Params.categories -}}{{ if gt $index 0 -}}, {{ end -}}<a class="stretched-link position-relative link-muted" href="{{ "/categories/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end -}}{{ end -}}
 {{ if .Params.contributors -}}&nbsp;by {{ range $index, $contributor := .Params.contributors }}{{ if gt $index 0 }}{{ if eq $index $last }} and {{ else }}, {{ end }}{{ end }}
   {{- with $.Site.GetPage "taxonomyTerm" (printf "contributors/%s" (urlize .)) -}}
   {{ if .Params.avatar -}}
@@ -9,4 +13,9 @@
       <img class="rounded-circle w-auto mx-1 lazyload blur-up" src="{{ $imageLq.RelPermalink }}" data-src="{{ $image.RelPermalink }}" alt="{{ .Title }}" width="30" height="30">
   {{ end -}}
 {{ end -}}
-<a class="stretched-link position-relative" href="{{ "/contributors/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end -}}{{ end -}}&nbsp;&hyphen;&nbsp;<strong>{{ .ReadingTime -}}&nbsp;min read</strong></small><p>
+<a class="stretched-link position-relative" href="{{ "/contributors/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end -}}{{ end -}}&nbsp;&hyphen;&nbsp;<strong>{{ .ReadingTime -}}{{ if  i18n "reading-time" }}
+    {{i18n "reading-time"}}
+    {{ else }}
+    min read
+    {{ end }}
+  </strong></small><p>


### PR DESCRIPTION
## Summary

- added translation for `read-time`for `Doks-core/layouts/blog/list.html` -> using partial `Doks-core/layouts/partials/list.html`
- added dateFormatting for `Doks-core/layouts/blog/list.html` -> using partial `Doks-core/layouts/partials/list.html`

## Basic example

See `blog-meta.html` [link](https://github.com/JanKru/doks-core/commit/590609f4c6b438327dfa4594d14c0695855845d3)

## Motivation
Translation is needed for multilingual support.
@h-enk if you think this makes sense, then I could add the `.Site.Params.dateFormat` and translation for reading time to [Doks-repo](https://github.com/h-enk/doks). 
If you are on the other side think this should be done by individuell user customization just close the pull request :) 
## Checks

- [ ] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request) -> 404?
- [ ] Passes `npm run test` -> no tests
