### PR TITLE
Fix site title with baseURL

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -18,7 +18,7 @@
   {{ end -}}
 
     <!-- Site title -->
-    <a class="navbar-brand me-auto me-lg-3" href="{{ "/" | relLangURL }}">{{ .Site.Title }}</a>
+    <a class="navbar-brand me-auto me-lg-3" href="{{ .Site.BaseURL | absURL }}">{{ .Site.Title }}</a>
 
     <!-- FlexSearch mobile -->
     {{ partial "main/showFlexSearch" . }}


### PR DESCRIPTION
## Summary

When you set a baseURL this isn't reported on the Title button on the left-top corner.

## Basic example

When you run:
```sh
npm run dev -- --baseURL http://localhost:1313/TEST
```

<img width="377" alt="image" src="https://github.com/gethyas/doks-core/assets/45263601/cfd690e7-451a-4225-8b32-ec557548ec62">

_Screenshot of header_

**Before patch**

<img width="641" alt="image" src="https://github.com/gethyas/doks-core/assets/45263601/e0b086d4-9a74-44d7-9c58-09e921aaf5f8">

_Screenshot of generated link on the header_

**After patch**

<img width="641" alt="image" src="https://github.com/gethyas/doks-core/assets/45263601/eca26936-f3c4-4917-a16c-6c13aa17a817">

_Screenshot of generated link on the header_

## Motivation

I'm doing this to fix an issue encounter during writing my own documentation.
My documentation isn't at the root of my website.
In my opinion this is a problem who need to be resolved globally not only on my project.
