### PR TITLE
Replace semantic whitespace with CSS

### DIFF
--- a/assets/scss/layouts/_footer.scss
+++ b/assets/scss/layouts/_footer.scss
@@ -2,15 +2,19 @@
   border-top: 1px solid $gray-200;
   padding-top: 1.125rem;
   padding-bottom: 1.125rem;
-}
 
-.footer ul {
-  margin-bottom: 0;
-}
+  ul {
+    margin-bottom: 0;
+  }
 
-.footer li {
-  font-size: $font-size-sm;
-  margin-bottom: 0;
+  li {
+    font-size: $font-size-sm;
+    margin-bottom: 0;
+  }
+
+  .list-inline-item:not(:last-child) {
+    margin-right: 1rem;
+  }
 }
 
 @include media-breakpoint-down(lg) {

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -5,7 +5,7 @@
         <ul class="list-inline">
           {{ range .Site.Menus.footer -}}
             <li class="list-inline-item"><a class="text-muted" href="{{ .URL | relURL }}">{{ .Name }}</a></li>
-          {{ end -}}
+          {{- end }}
         </ul>
       </div>
       <div class="col-lg-8 text-center text-lg-end">


### PR DESCRIPTION
## Summary

Before this PR, the layout differed between the minified (`hugo ---minify`) and the unminified site. The reason was semantic whitespace generated by a subtly wrong usage of Go's template language. This PR fixes that and increases the CSS spacing instead, so the minified and unminified sites look identical.

## Motivation

Aesthetics.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
