### PR TITLE
Fix semantic whitespace in lang selector

### DIFF
--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -144,6 +144,11 @@
   height: 0;
 }
 
+span#doks-language-current {
+  margin-left: 0.2rem;
+  margin-right: 0.1rem;
+}
+
 button#doks-languages {
   margin: 0.25rem 0 0;
 
@@ -168,7 +173,7 @@ button#doks-versions {
 }
 
 .offcanvas-header {
-  border-bottom: 1px solid $gray-300;  
+  border-bottom: 1px solid $gray-300;
   padding-top: 1.0625rem;
   padding-bottom: 0.8125rem;
 }
@@ -587,7 +592,7 @@ h5.offcanvas-title {
   .navbar-nav {
     margin-top: 1rem;
   }
-  
+
   .dropdown-menu {
     box-shadow: none !important;
     background: transparent !important;

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -163,7 +163,7 @@
                 <path d="M12 20l4 -9l4 9"></path>
                 <path d="M19.1 18h-6.2"></path>
               </svg>
-              {{ .Site.Language.LanguageName }}
+              {{- /* trim preceding whitespace */}}<span id="doks-language-current"></span>{{ .Site.Language.LanguageName }}</span>{{/* trim subsequent whitespace */ -}}
               <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-down" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                 <path d="M6 9l6 6l6 -6"></path>


### PR DESCRIPTION
## Summary

Removes semantic whitespace in the language selector title (the language name) and adds CSS margins instead. This ensures the site looks exactly the same unminified and minified (i.e. with `hugo --minify`).

## Motivation

Aesthetics.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
