### PR TITLE
Tweak estimated reading time display

### DIFF
--- a/assets/scss/layouts/_posts.scss
+++ b/assets/scss/layouts/_posts.scss
@@ -97,3 +97,12 @@ h2.section-title {
   text-align: center;
   margin-top: 2.5rem;
 }
+
+span.reading-time {
+  margin-left: 2rem;
+
+  svg {
+    margin-right: 0.3rem;
+    vertical-align: -0.4rem;
+  }
+}

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,0 +1,44 @@
+[404_text]
+other = "Die aufgerufene Seite existiert nicht oder wurde verschoben."
+
+[404_title]
+other = "Seite nicht gefunden"
+
+[browse]
+other = "Browse"
+
+[chapter_next]
+other = "Danach"
+
+[chapter_previous]
+other = "Davor"
+
+[edit_page]
+other = "Editiere diese Seite auf"
+
+[get_started]
+other = "Loslegen"
+
+[last_updated]
+other = "Zuletzt aktualisiert am"
+
+[on_this_page]
+other = "Auf dieser Seite"
+
+[search_loading]
+other = "Suchindex wird geladen…"
+
+[search_no_recent]
+other = "Keine kürzlich durchgeführten Suchanfragen"
+
+[search_no_results]
+other = "Keine Resultate"
+
+[search_placeholder]
+other = "Suche"
+
+[search_title]
+other = "Suche"
+
+[video_unsupported]
+other = "Ihr Browser unterstützt keine integrierten Videos, aber keine Sorge, Sie können <a href=\"{{ .RelPermalink }}\">es herunterladen</a> und mit Ihrem Lieblings-Videoplayer ansehen!"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -25,6 +25,9 @@ other = "Zuletzt aktualisiert am"
 [on_this_page]
 other = "Auf dieser Seite"
 
+[reading_time]
+other = "Minuten Lesedauer"
+
 [search_loading]
 other = "Suchindex wird geladen…"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,44 @@
+[404_text]
+other = "The page you are looking for doesn't exist or has been moved."
+
+[404_title]
+other = "Page not found :("
+
+[browse]
+other = "Browse"
+
+[chapter_next]
+other = "Next"
+
+[chapter_previous]
+other = "Prev"
+
+[edit_page]
+other = "Edit this page on"
+
+[get_started]
+other = "Example Guide"
+
+[last_updated]
+other = "Last updated on"
+
+[on_this_page]
+other = "Example Guide"
+
+[search_loading]
+other = "Loading search index…"
+
+[search_no_recent]
+other = "No recent searches"
+
+[search_no_results]
+other = "No results"
+
+[search_placeholder]
+other = "Search"
+
+[search_title]
+other = "Search"
+
+[video_unsupported]
+other = "Your browser doesn't support embedded videos, but don't worry, you can <a href=\"{{ .RelPermalink }}\">download it</a> and watch it with your favorite video player!"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -25,6 +25,9 @@ other = "Last updated on"
 [on_this_page]
 other = "Example Guide"
 
+[reading_time]
+other = "min read"
+
 [search_loading]
 other = "Loading search index…"
 

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -25,6 +25,9 @@ other = "Laatst bijgewerkt op"
 [on_this_page]
 other = "Op deze pagina"
 
+[reading_time]
+other = "minuten leestijd"
+
 [search_loading]
 other = "Zoekindex wordt geladen…"
 

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -1,0 +1,44 @@
+[404_text]
+other = "De gezochte pagina bestaat niet of deze is verplaatst."
+
+[404_title]
+other = "Pagina niet gevonden :("
+
+[browse]
+other = "Browse"
+
+[chapter_next]
+other = "Volgende"
+
+[chapter_previous]
+other = "Voorheen"
+
+[edit_page]
+other = "Bewerk deze pagina op"
+
+[get_started]
+other = "Aan de slag"
+
+[last_updated]
+other = "Laatst bijgewerkt op"
+
+[on_this_page]
+other = "Op deze pagina"
+
+[search_loading]
+other = "Zoekindex wordt geladen…"
+
+[search_no_recent]
+other = "Geen recente zoekopdrachten"
+
+[search_no_results]
+other = "Geen resultaten"
+
+[search_placeholder]
+other = "Zoeken"
+
+[search_title]
+other = "Zoeken"
+
+[video_unsupported]
+other = "Je browser ondersteunt geen ingesloten video's, maar maak je geen zorgen, je kunt <a href=\"{{ .RelPermalink }}\">het downloaden</a> en bekijken met je favoriete videospeler!"

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -2,8 +2,8 @@
 <div class="row justify-content-center">
   <div class="col-md-12 col-lg-10 col-xl-8">
     <article>
-      <h1 class="text-center">{{ i18n "404-title" }}</h1>
-      <p class="text-center">{{ i18n "404-text" }}</p>
+      <h1 class="text-center">{{ i18n "404_title" }}</h1>
+      <p class="text-center">{{ i18n "404_text" }}</p>
     </article>
   </div>
 </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
     </div>
     <div class="col-lg-9 col-xl-8 text-center">
       <p class="lead">{{ .Params.lead | safeHTML }}</p>
-      <a class="btn btn-primary btn-cta rounded-pill btn-lg my-3" href="/docs/{{ if site.Data.doks.docsVersioning }}{{ site.Data.doks.docsVersion }}/{{ end }}guides/example-guide/" role="button">{{ i18n "get-started" }}</a>
+      <a class="btn btn-primary btn-cta rounded-pill btn-lg my-3" href="/docs/{{ if site.Data.doks.docsVersioning }}{{ site.Data.doks.docsVersion }}/{{ end }}guides/example-guide/" role="button">{{ i18n "get_started" }}</a>
       {{ .Content }}
     </div>
   </div>
@@ -51,7 +51,7 @@
   <div class="row justify-content-center text-center">
     <div class="col-lg-7">
       <h2 class="mt-2">Start building with Doks today</h2>
-      <a class="btn btn-primary rounded-pill px-4 my-2" href="/docs/{{ if site.Data.doks.docsVersioning }}{{ site.Data.doks.docsVersion }}/{{ end }}prologue/introduction/" role="button">{{ i18n "get-started" }}</a>
+      <a class="btn btn-primary rounded-pill px-4 my-2" href="/docs/{{ if site.Data.doks.docsVersioning }}{{ site.Data.doks.docsVersion }}/{{ end }}prologue/introduction/" role="button">{{ i18n "get_started" }}</a>
     </div>
   </div>
 </section>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
     </div>
     <div class="col-lg-9 col-xl-8 text-center">
       <p class="lead">{{ .Params.lead | safeHTML }}</p>
-      <a class="btn btn-primary btn-cta rounded-pill btn-lg my-3" href="/docs/{{ if site.Params.doks.docsVersioning }}{{ site.Params.doks.docsVersion }}/{{ end }}guides/example-guide/" role="button">{{ i18n "get-started" }}</a>
+      <a class="btn btn-primary btn-cta rounded-pill btn-lg my-3" href="/docs/{{ if site.Params.doks.docsVersioning }}{{ site.Params.doks.docsVersion }}/{{ end }}guides/example-guide/" role="button">{{ i18n "get_started" }}</a>
       {{ .Content }}
     </div>
   </div>
@@ -51,7 +51,7 @@
   <div class="row justify-content-center text-center">
     <div class="col-lg-7">
       <h2 class="mt-2">Start building with Doks today</h2>
-      <a class="btn btn-primary rounded-pill px-4 my-2" href="/docs/{{ if site.Params.doks.docsVersioning }}{{ site.Params.doks.docsVersion }}/{{ end }}prologue/introduction/" role="button">{{ i18n "get-started" }}</a>
+      <a class="btn btn-primary rounded-pill px-4 my-2" href="/docs/{{ if site.Params.doks.docsVersioning }}{{ site.Params.doks.docsVersion }}/{{ end }}prologue/introduction/" role="button">{{ i18n "get_started" }}</a>
     </div>
   </div>
 </section>

--- a/layouts/partials/main/blog-meta.html
+++ b/layouts/partials/main/blog-meta.html
@@ -1,17 +1,37 @@
-{{ $last := sub (len .Params.contributors) 1 }}
-<p><small> {{ if $.Site.Params.dateFormat }}
-  {{ .PublishDate | time.Format .Site.Params.dateFormat }}
-  {{ else }}
-  {{ .PublishDate.Format "January 2, 2006" }}
-  {{ end }}{{ if .Params.categories -}}&nbsp;in&nbsp;{{ range $index, $category := .Params.categories -}}{{ if gt $index 0 -}}, {{ end -}}<a class="stretched-link position-relative link-muted" href="{{ "/categories/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end -}}{{ end -}}
-{{ if .Params.contributors -}}&nbsp;by {{ range $index, $contributor := .Params.contributors }}{{ if gt $index 0 }}{{ if eq $index $last }} and {{ else }}, {{ end }}{{ end }}
-  {{- with $.Site.GetPage "taxonomyTerm" (printf "contributors/%s" (urlize .)) -}}
-  {{ if .Params.avatar -}}
-    {{ $image := .Resources.GetMatch (printf "**%s" .Params.avatar) -}}
-    {{ $imageLq := $image.Resize "15x15 webp q95" -}}
-    {{ $image = $image.Resize "60x60 webp q95" -}}
-      <img class="rounded-circle w-auto mx-1 lazyload blur-up" src="{{ $imageLq.RelPermalink }}" data-src="{{ $image.RelPermalink }}" alt="{{ .Title }}" width="30" height="30">
-  {{ end -}}
-{{ end -}}
-<a class="stretched-link position-relative" href="{{ "/contributors/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end -}}{{ end -}}&nbsp;&hyphen;&nbsp;<strong>{{ .ReadingTime -}}{{ i18n "reading_time" }}</strong>
-</small></p>
+{{ $last := sub (len .Params.contributors) 1 -}}
+<p>
+  <small>
+    {{- time.Format (default ":date_long" .Site.Params.dateFormat) .PublishDate -}}
+    {{- with .Params.categories -}}
+      &nbsp;in&nbsp;
+      {{- range $index, $category := . -}}
+        {{ if gt $index 0 }}, {{ end -}}
+        <a class="stretched-link position-relative link-muted" href="{{ "/categories/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>
+      {{- end }}
+    {{- end }}
+    {{- with .Params.contributors -}}
+      &nbsp;by&nbsp;
+      {{- range $index, $contributor := . -}}
+        {{- if gt $index 0 }}{{ if eq $index $last }} and {{ else }}, {{ end }}{{ end -}}
+        {{- with $.Site.GetPage "taxonomyTerm" (printf "contributors/%s" (urlize .)) -}}
+          {{ if $.Params.avatar -}}
+            {{ $image := .Resources.GetMatch (printf "**%s" .Params.avatar) -}}
+            {{ $imageLq := $image.Resize "15x15 webp q95" -}}
+            {{ $image = $image.Resize "60x60 webp q95" -}}
+            <img class="rounded-circle w-auto mx-1 lazyload blur-up" src="{{ $imageLq.RelPermalink }}" data-src="{{ $image.RelPermalink }}" alt="{{ .Title }}" width="30" height="30">
+          {{- end }}
+        {{- end -}}
+        <a class="stretched-link position-relative" href="{{ "/contributors/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>
+      {{- end }}
+    {{- end -}}
+    {{- /* NOTE: class 'stretched-link' is necessary to properly display the title attribute on hover */ -}}
+    <span class="stretched-link reading-time" title="{{ i18n "reading_time" }}">{{/* trim subsequent whitespace */ -}}
+      <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-clock" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+        <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"></path>
+        <path d="M12 7v5l3 3"></path>
+      </svg>
+      {{- .ReadingTime }}&nbsp;{{ i18n "minute" .ReadingTime -}}
+    </span>{{/* trim subsequent whitespace */ -}}
+  </small>
+</p>

--- a/layouts/partials/main/blog-meta.html
+++ b/layouts/partials/main/blog-meta.html
@@ -13,9 +13,5 @@
       <img class="rounded-circle w-auto mx-1 lazyload blur-up" src="{{ $imageLq.RelPermalink }}" data-src="{{ $image.RelPermalink }}" alt="{{ .Title }}" width="30" height="30">
   {{ end -}}
 {{ end -}}
-<a class="stretched-link position-relative" href="{{ "/contributors/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end -}}{{ end -}}&nbsp;&hyphen;&nbsp;<strong>{{ .ReadingTime -}}{{ with  i18n "reading-time" }}
-  {{ . }}
-  {{ else }}
-  min read
-  {{ end }}
-</strong></small><p>
+<a class="stretched-link position-relative" href="{{ "/contributors/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>{{ end -}}{{ end -}}&nbsp;&hyphen;&nbsp;<strong>{{ .ReadingTime -}}{{ i18n "reading_time" }}</strong>
+</small></p>

--- a/layouts/partials/sidebar/docs-toc-desktop.html
+++ b/layouts/partials/sidebar/docs-toc-desktop.html
@@ -1,6 +1,6 @@
 <div class="page-links">
   {{ if partial "private/has-headings.html" . -}}
-    <h3>{{ i18n "on-this-page" }}</h3>
+    <h3>{{ i18n "on_this_page" }}</h3>
     {{ if eq site.Data.doks.scrollSpy true -}}
       {{ .TableOfContents | replaceRE "<nav id=\"TableOfContents\">" "<nav id=\"toc\">" | safeHTML -}}
     {{- else -}}

--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -8,7 +8,7 @@
   /*    @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
   /*
   */ -}}
-  
+
   {{- $video_src := .Get "src" -}}
   {{- $video_mp4 := "" -}}
   {{- $video_webm := "" -}}
@@ -17,13 +17,13 @@
   {{- $width := "100%" -}}
   {{- $filenotfound := true -}}
   {{- $unsupportedfile := true -}}
-  
+
   {{- /* Find all files with filename (without suffix) matching "src" parameter. */ -}}
   {{- $video_files := (.Page.Resources.Match (printf "%s*" $video_src)) -}}
-  
+
   {{- /* Find first image file with filename (without suffix) matching "src" parameter. */ -}}
   {{- $poster := ((.Page.Resources.ByType "image").GetMatch (printf "%s*" $video_src)) -}}
-  
+
   {{- /* Find in page bundle all valid video files with matching name. */ -}}
   {{- with $video_files -}}
     {{- $filenotfound = false -}}
@@ -42,7 +42,7 @@
       {{- end -}}
     {{- end -}}
   {{- end -}}
-  
+
   {{- if $filenotfound -}}
     {{- /* No file of given name was found, we stop here. */ -}}
     {{- errorf "No file with filename %q found." $video_src -}}
@@ -62,6 +62,6 @@
       <source src="{{ .RelPermalink }}" type="video/mp4">
       {{- $video_dl = . -}}
     {{- end }}
-    <span>{{ i18n "videoUnsupported" $video_dl | safeHTML}}</span>
+    <span>{{ i18n "video_unsupported" $video_dl | safeHTML}}</span>
   </video>
   {{- end -}}


### PR DESCRIPTION
## Summary

- Refactors the `main/blog-meta.html` partial (simpler, bettter readable etc.)
- Adds default translations for new `minute` and `reading_time` i18n keys. Note that the value of `reading_time` is only displayed on hover (as a hint for what kind of time we're displaying here).
- Adds a [`clock`](https://tabler-icons.io/i/clock) tabler icon; [`hourglass-high`](https://tabler-icons.io/i/hourglass-high) would be a suitable alternative, but doesn't look convincing IMHO.

**Note that this PR build upon https://github.com/gethyas/doks-core/pull/60.**

## Motivation

Aesthetics.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
