### PR TITLE
Fix estimated reading time

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -22,11 +22,15 @@ other = "Loslegen"
 [last_updated]
 other = "Zuletzt aktualisiert am"
 
+[minute]
+one = "Minute"
+other = "Minuten"
+
 [on_this_page]
 other = "Auf dieser Seite"
 
 [reading_time]
-other = "Minuten Lesedauer"
+other = "Geschätzte Lesedauer"
 
 [search_loading]
 other = "Suchindex wird geladen…"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -22,11 +22,15 @@ other = "Example Guide"
 [last_updated]
 other = "Last updated on"
 
+[minute]
+one = "minute"
+other = "minutes"
+
 [on_this_page]
 other = "Example Guide"
 
 [reading_time]
-other = "min read"
+other = "Estimated reading time"
 
 [search_loading]
 other = "Loading search index…"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -22,11 +22,15 @@ other = "Aan de slag"
 [last_updated]
 other = "Laatst bijgewerkt op"
 
+[minute]
+one = "minuut"
+other = "minuten"
+
 [on_this_page]
 other = "Op deze pagina"
 
 [reading_time]
-other = "minuten leestijd"
+other = "Geschatte leestijd"
 
 [search_loading]
 other = "Zoekindex wordt geladen…"

--- a/layouts/partials/main/blog-meta.html
+++ b/layouts/partials/main/blog-meta.html
@@ -24,15 +24,14 @@
         <a class="stretched-link position-relative" href="{{ "/contributors/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>
       {{- end }}
     {{- end -}}
-    {{- /* NOTE: class 'stretched-link' is necessary to properly display the title attribute on hover */ -}}
-    <span class="reading-time">{{/* trim subsequent whitespace */ -}}
+    {{- /* NOTE: classes 'stretched-link position-relative' are necessary to properly display the title attribute on hover */ -}}
+    <span class="stretched-link position-relative reading-time" title="{{ i18n "reading_time" }}">{{/* trim subsequent whitespace */ -}}
       <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-clock" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-        <title>Clock icon</title>
         <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
         <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"></path>
         <path d="M12 7v5l3 3"></path>
       </svg>
-      {{- .ReadingTime }}&nbsp;{{ i18n "reading_time" .ReadingTime -}}
+      {{- .ReadingTime }}&nbsp;{{ i18n "minute" .ReadingTime -}}
     </span>{{/* trim subsequent whitespace */ -}}
   </small>
 </p>


### PR DESCRIPTION
## Summary

Add bits that were missing in https://github.com/gethyas/doks-core/pull/63 (sorry for that) and tweaks the reading time to display like I originally intended, i.e. with proper translation and pluralization of minute/minutes and additional hover info:

![Bildschirmfoto vom 2023-10-10 14-23-26](https://github.com/gethyas/doks-core/assets/20040931/0a325a45-e9df-4f5e-a159-15792db6f143)

Note that the CSS behind Bootstrap's `stretched-link position-relative` classes here is beyond my expertise. If class `stretched-link` is omitted from the `reading-time` `<span>`, the hover info is not displayed. If `stretched-link` is set but without `position-relative`, the card is not clickable anymore. So I just set both which gives the result I intended.

## Motivation

Aesthetics.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
