### PR TITLE
Use Bootstrap's font-size SCSS variables where appropriate

### DIFF
--- a/assets/scss/components/_alerts.scss
+++ b/assets/scss/components/_alerts.scss
@@ -137,7 +137,7 @@
 
 .alert-text {
   margin-right: -3rem;
-  font-size: 1rem;
+  font-size: $font-size-base;
 }
 
 .alert-dismissible .btn-close {

--- a/assets/scss/components/_callouts.scss
+++ b/assets/scss/components/_callouts.scss
@@ -36,10 +36,10 @@
     display: block;
     margin-bottom: 0.25rem;
     font-weight: $headings-font-weight;
-    font-size: 1.125rem;
+    font-size: $font-size-md;
 
     @include media-breakpoint-up(lg) {
-      font-size: 1.25rem;
+      font-size: $font-size-lg;
     }
 
     .svg-inline {
@@ -92,7 +92,7 @@
 .callout.callout-caution {
   border-color: var(--sl-color-orange);
   background-color: var(--sl-color-orange-high);
-  
+
   .callout-title {
     color: var(--sl-color-orange-low);
   }
@@ -105,7 +105,7 @@
 .callout.callout-danger {
   border-color: var(--sl-color-red);
   background-color: var(--sl-color-red-high);
-  
+
   .callout-title {
     color: var(--sl-color-red-low);
   }
@@ -127,50 +127,50 @@
   .callout.callout-note {
     border-color: var(--sl-color-blue);
     background-color: var(--sl-color-blue-low);
-  
+
     .callout-title {
       color: var(--sl-color-blue-high);
     }
-  
+
     code {
-      background: shade-color($info, 75%);    
+      background: shade-color($info, 75%);
     }
   }
-  
+
   .callout.callout-tip {
     border-color: var(--sl-color-purple);
     background-color: var(--sl-color-purple-low);
-  
+
     .callout-title {
       color: var(--sl-color-purple-high);
     }
-  
+
     code {
       background: shade-color($purple, 75%);
     }
   }
-  
+
   .callout.callout-caution {
     border-color: var(--sl-color-orange);
     background-color: var(--sl-color-orange-low);
-    
+
     .callout-title {
       color: var(--sl-color-orange-high);
     }
-  
+
     code {
       background: shade-color($yellow, 75%);
     }
   }
-  
+
   .callout.callout-danger {
     border-color: var(--sl-color-red);
     background-color: var(--sl-color-red-low);
-    
+
     .callout-title {
       color: var(--sl-color-red-high);
     }
-  
+
     code {
       background: shade-color($red, 75%);
     }

--- a/assets/scss/components/_comments.scss
+++ b/assets/scss/components/_comments.scss
@@ -24,7 +24,7 @@
 
 blockquote {
   margin-bottom: 1rem;
-  font-size: 1.25rem;
+  font-size: $font-size-lg;
   border-left: 3px solid $gray-300;
   padding-left: 1rem;
 }

--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -13,7 +13,7 @@ figure img {
 
 figure figcaption {
   margin: 0.25rem 0 0.75rem;
-  font-size: 0.875em;
+  font-size: $font-size-sm;
   color: #6c757d;
 }
 


### PR DESCRIPTION
## Summary

 This PR uses Bootstrap's `font-size` SCSS variables instead of hardcoded values (the actual computed values when rendered stay the same).

## Motivation

To my understanding, using Bootstrap's SCSS variables instead of hardcoded values whenever possible is more consistent (i.e. easier understandable for humans) and leads to easier maintainable code.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
