### PR TITLE
Fix footnote styling

### DIFF
--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -356,13 +356,6 @@ body {
   }
 }
 
-sup[id]::after {
-  display: block;
-  height: 6rem;
-  margin-top: -6rem;
-  content: "";
-}
-
 a.footnote-backref {
   text-decoration: none;
 }
@@ -446,7 +439,7 @@ li input[type="checkbox"]:checked {
   .svg-lightmode {
     display: none;
   }
-  
+
   .svg-darkmode {
     display: block;
   }


### PR DESCRIPTION
## Summary

Fixes styling of footnotes. The affected CSS rule caused the `<sup>` element from footnote references to be unclickable and have a line break before it.

Note that I have no clue what purpose the affected CSS rule was originally intended to serve.

## Motivation

Fix footnotes in content.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
