### PR TITLE
Tweak footnote font-size

### DIFF
--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -363,6 +363,10 @@ sup[id]::after {
   content: "";
 }
 
+div.footnotes {
+  font-size: $font-size-sm;
+}
+
 a.footnote-backref {
   text-decoration: none;
 }
@@ -446,7 +450,7 @@ li input[type="checkbox"]:checked {
   .svg-lightmode {
     display: none;
   }
-  
+
   .svg-darkmode {
     display: block;
   }


### PR DESCRIPTION
## Summary

Lowers footnote font size, which just looks better.

## Motivation

Aesthetics.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
