### PR TITLE
Improve callouts

### DIFF
--- a/assets/scss/components/_callouts.scss
+++ b/assets/scss/components/_callouts.scss
@@ -6,7 +6,10 @@
   --#{$prefix}link-color-rgb: var(--callout-link);
   --#{$prefix}code-color: var(--callout-code-color);
 
-  padding: 1.25rem;
+  padding-top: 1.5rem;
+  padding-right: 1.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 1rem;
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
   color: var(--callout-color, inherit);
@@ -14,37 +17,8 @@
   border-left: 0.25rem solid var(--callout-border, var(--bs-gray-300));
   border-radius: 0;
 
-  h4 {
-    margin-top: 0;
-    margin-bottom: .25rem;
-  }
-
-  > :last-child {
-    margin-bottom: 0;
-  }
-
-  + .callout {
-    margin-top: -.25rem;
-  }
-
-  .svg-inline {
-    position: relative;
-    margin: -0.375rem 0 0;
-  }
-
-  .callout-title {
-    display: block;
-    margin-bottom: 0.25rem;
-    font-weight: $headings-font-weight;
-    font-size: 1.125rem;
-
-    @include media-breakpoint-up(lg) {
-      font-size: 1.25rem;
-    }
-
-    .svg-inline {
-      margin-right: 0.5rem;
-    }
+  a {
+    text-decoration: underline;
   }
 
   code {
@@ -52,22 +26,30 @@
     color: inherit;
   }
 
-  a {
-    @extend .alert-link;
-
-    font-weight: $font-weight-medium;
-  }
-
   .highlight {
     background-color: rgba($black, .05);
   }
+
+  .callout-icon.svg-inline {
+    flex-shrink: 0;
+    margin-right: 0.5rem;
+    margin-bottom: 1rem;
+    height: calc(#{$line-height-base} * #{$font-size-md});
+  }
+
+  .callout-title {
+    font-weight: $headings-font-weight;
+  }
 }
 
+// Colors
 .callout.callout-note {
   border-color: var(--sl-color-blue);
   background-color: var(--sl-color-blue-high);
 
-  .callout-title {
+  .callout-icon,
+  .callout-title,
+  .callout-body {
     color: var(--sl-color-blue-low);
   }
 
@@ -80,7 +62,9 @@
   border-color: var(--sl-color-purple);
   background-color: var(--sl-color-purple-high);
 
-  .callout-title {
+  .callout-icon,
+  .callout-title,
+  .callout-body {
     color: var(--sl-color-purple-low);
   }
 
@@ -92,8 +76,10 @@
 .callout.callout-caution {
   border-color: var(--sl-color-orange);
   background-color: var(--sl-color-orange-high);
-  
-  .callout-title {
+
+  .callout-icon,
+  .callout-title,
+  .callout-body {
     color: var(--sl-color-orange-low);
   }
 
@@ -105,8 +91,10 @@
 .callout.callout-danger {
   border-color: var(--sl-color-red);
   background-color: var(--sl-color-red-high);
-  
-  .callout-title {
+
+  .callout-icon,
+  .callout-title,
+  .callout-body {
     color: var(--sl-color-red-low);
   }
 
@@ -127,50 +115,58 @@
   .callout.callout-note {
     border-color: var(--sl-color-blue);
     background-color: var(--sl-color-blue-low);
-  
-    .callout-title {
+
+    .callout-icon,
+    .callout-title,
+    .callout-body {
       color: var(--sl-color-blue-high);
     }
-  
+
     code {
-      background: shade-color($info, 75%);    
+      background: shade-color($info, 75%);
     }
   }
-  
+
   .callout.callout-tip {
     border-color: var(--sl-color-purple);
     background-color: var(--sl-color-purple-low);
-  
-    .callout-title {
+
+    .callout-icon,
+    .callout-title,
+    .callout-body {
       color: var(--sl-color-purple-high);
     }
-  
+
     code {
       background: shade-color($purple, 75%);
     }
   }
-  
+
   .callout.callout-caution {
     border-color: var(--sl-color-orange);
     background-color: var(--sl-color-orange-low);
-    
-    .callout-title {
+
+    .callout-icon,
+    .callout-title,
+    .callout-body {
       color: var(--sl-color-orange-high);
     }
-  
+
     code {
       background: shade-color($yellow, 75%);
     }
   }
-  
+
   .callout.callout-danger {
     border-color: var(--sl-color-red);
     background-color: var(--sl-color-red-low);
-    
-    .callout-title {
+
+    .callout-icon,
+    .callout-title,
+    .callout-body {
       color: var(--sl-color-red-high);
     }
-  
+
     code {
       background: shade-color($red, 75%);
     }

--- a/assets/scss/components/_callouts.scss
+++ b/assets/scss/components/_callouts.scss
@@ -6,12 +6,6 @@
   --#{$prefix}link-color-rgb: var(--callout-link);
   --#{$prefix}code-color: var(--callout-code-color);
 
-  padding-top: 1.5rem;
-  padding-right: 1.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 1rem;
-  margin-top: 1.5rem;
-  margin-bottom: 1.5rem;
   color: var(--callout-color, inherit);
   background-color: var(--callout-bg, var(--bs-gray-100));
   border-left: 0.25rem solid var(--callout-border, var(--bs-gray-300));
@@ -32,8 +26,6 @@
 
   .callout-icon.svg-inline {
     flex-shrink: 0;
-    margin-right: 0.5rem;
-    margin-bottom: 1rem;
     height: calc(#{$line-height-base} * #{$font-size-md});
   }
 

--- a/layouts/shortcodes/callout.html
+++ b/layouts/shortcodes/callout.html
@@ -13,9 +13,9 @@
 {{- $icon := .Get "icon" -}}
 {{- $title := .Get "title" -}}
 
-<div class="callout callout-{{ $css_class }} d-flex flex-row">
+<div class="callout callout-{{ $css_class }} d-flex flex-row mt-4 mb-4 pt-4 pe-4 pb-2 ps-3">
   {{ with $icon -}}
-    {{ partial "inline-svg" (dict "src" $icon "class" "callout-icon") }}
+    {{ partial "inline-svg" (dict "src" $icon "class" "callout-icon me-2 mb-3") }}
   {{- end }}
   <div class="callout-content">
     {{ with $title -}}

--- a/layouts/shortcodes/callout.html
+++ b/layouts/shortcodes/callout.html
@@ -1,30 +1,30 @@
 {{- /*
-  Usage: `callout "type"`, where `type` is one of light (default), info, danger, or warning
+  Usage: `callout "type"`, where `type` is one of "note" (default), "info", "danger", or "warning"
   Based on: https://github.com/twbs/bootstrap/blob/283cbd902669732943885e94115a0e29a952baf6/site/layouts/shortcodes/callout.html
 */ -}}
 
-{{ $css_class := "" }}
-{{ if .IsNamedParams -}}
-  {{ $css_class = .Get "context" | default "note" -}}
-{{ else -}}
-  {{ $css_class = .Get 0 | default "note" -}}
-{{ end -}}
+{{- $css_class := "" -}}
+{{- if .IsNamedParams -}}
+  {{- $css_class = .Get "context" | default "note" -}}
+{{- else -}}
+  {{- $css_class = .Get 0 | default "note" -}}
+{{- end -}}
 
-{{ $icon := .Get "icon" -}}
-{{ $title := .Get "title" -}}
+{{- $icon := .Get "icon" -}}
+{{- $title := .Get "title" -}}
 
-{{ $flex_direction := "row" }}
-{{ if or (and $icon $title) ($title) -}}
-  {{ $flex_direction = "column"}}
-{{ end -}}
-
-<div class="callout callout-{{ $css_class }} d-flex flex-{{ $flex_direction }}">
-  {{- if and $icon $title -}}
-    <div class="callout-title">{{ partial "inline-svg" (dict "src" $icon "stroke-width" "1.5") }}{{ $title | safeHTML }}</div>
-  {{- else if $icon -}}
-    <div class="callout-icon me-2">{{ partial "inline-svg" (dict "src" $icon "stroke-width" "1.5") }}</div>
-  {{- else if $title -}}
-    <p class="callout-title">{{ $title | safeHTML }}</p>
-  {{- end -}}
-  <div class="callout-content">{{ .Inner | markdownify }}</div>
+<div class="callout callout-{{ $css_class }} d-flex flex-row">
+  {{ with $icon -}}
+    {{ partial "inline-svg" (dict "src" $icon "class" "callout-icon") }}
+  {{- end }}
+  <div class="callout-content">
+    {{ with $title -}}
+      <div class="callout-title">
+        {{ . | $.Page.RenderString (dict "display" "block") }}
+      </div>
+    {{- end }}
+    <div class="callout-body">
+      {{ .Inner | $.Page.RenderString (dict "display" "block") }}
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## Summary

Tweak [Callouts](https://getdoks.org/docs/guides/shortcodes/#callouts) to
- yield optimal result with all possible input combinations.
- support Markdown formatting in `title`.
- generate predictable markup (text always wrapped in `<p></p>` etc.).
- not attempt to set `stroke-width` on the SVG (cannot work).
- consistently use Bootstrap's utility classes for margins and padding.

Before, for a callout with icon, the layout differed depending on whether a title was supplied or not. Margins also weren't optimal.

I thoroughly tested the overhauled callouts!

## Example screenshots

Screenshots are based on (a subset of) the following shortcode invocation:

```
{{< callout context="tip" icon="viewfinder" title="Attention is `all` u need" >}}
  Caution and danger callouts are helpful for drawing a user’s attention to details that may trip them up. If you find yourself using these a lot, it may also be a sign that the thing you are documenting could benefit from being redesigned.

  Caution and danger callouts are helpful for drawing a user’s attention to details that may trip them up. If you find yourself using these a lot, it may also be a sign that the thing you are documenting could benefit from being redesigned.
  
  Caution and danger callouts are helpful for drawing a user’s attention to details that may trip them up. If you find yourself using these a lot, it may also be a sign that the thing you are documenting could benefit from being redesigned.
{{< /callout >}}
```

![Screenshot 2023-10-26 at 07-49-47 Privacy policy](https://github.com/gethyas/doks-core/assets/20040931/d122b4c3-0dbc-4e96-ac04-934d677e801f)

![Screenshot 2023-10-26 at 07-50-00 Privacy policy](https://github.com/gethyas/doks-core/assets/20040931/a35efd52-a249-479a-ac69-31776ef014e2)

![Screenshot 2023-10-26 at 07-51-43 Privacy policy](https://github.com/gethyas/doks-core/assets/20040931/ccf90e11-c3d0-4cb1-b719-92249e4c6e76)

![Screenshot 2023-10-26 at 07-50-14 Privacy policy](https://github.com/gethyas/doks-core/assets/20040931/c31b5895-e63f-43f9-9443-56484e288817)

![Screenshot 2023-10-26 at 07-50-27 Privacy policy](https://github.com/gethyas/doks-core/assets/20040931/a58348f1-7e32-4d95-8832-d0018429ade6)

![Screenshot 2023-10-26 at 07-51-57 Privacy policy](https://github.com/gethyas/doks-core/assets/20040931/80310768-a4c6-4cf0-bf7c-05bed4e1bb89)

![Screenshot 2023-10-26 at 07-51-15 Privacy policy](https://github.com/gethyas/doks-core/assets/20040931/1d444eb3-3546-4f36-a40c-5eef4c45a709)

![Screenshot 2023-10-26 at 09-02-08 Privacy policy](https://github.com/gethyas/doks-core/assets/20040931/85c3c80e-fdc1-45cb-8e12-47e307848ce2)

![Screenshot 2023-10-26 at 07-50-59 Privacy policy](https://github.com/gethyas/doks-core/assets/20040931/ef4ab0d4-fca2-4321-9ff7-eadd8f1fb5a6)

(The last one ist just an empty callout, i.e. `{{< callout context="tip" >}}{{< /callout >}}`.)

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
