### PR TITLE
Tweak footnote `scroll-margin-top`

### DIFF
--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -357,7 +357,7 @@ body {
 }
 
 sup[id] {
-  scroll-margin-top: 5rem; 
+  scroll-margin-top: 4.5rem; 
 }
 
 div.footnotes {


### PR DESCRIPTION
## Summary

Tweak positioning when jumping back to footnote (it's better readable if line above footnote is fully hidden under the navbar).

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
