### PR TITLE
Adds Diagrams render hook

### DIFF
--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -81,8 +81,30 @@ code.language-mermaid {
   }
 }
 
+// Math styling
+.math-block {
+  display: block;
+  margin: 2rem 0;
+  overflow-x: auto;
+}
+
+.math-inline {
+  display: inline;
+}
+
 @include color-mode(dark) {
+  .math-inline img,
   .math-block img {
     filter: invert(1);
   }
+}
+
+// Diagram styling
+img.diagram {
+  height: auto;
+  width: 100%;
+}
+
+img.diagram-kroki-mermaid {
+  background: $white;
 }

--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -103,8 +103,9 @@ code.language-mermaid {
 img.diagram {
   height: auto;
   width: 100%;
+  margin: 1rem 0 2rem;
 }
-
+ 
 img.diagram-kroki-mermaid {
   background: $white;
 }

--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -4,9 +4,22 @@ kbd,
 samp {
   font-family: $font-family-monospace;
   font-size: $font-size-sm;
-  border-radius: $border-radius;
 }
 
+code:not(:where(.not-content *)) {
+  background-color: var(--sl-color-gray-6);
+  margin-block: -0.125rem;
+  padding: 0.125rem 0.375rem;
+  color: inherit;
+}
+
+@include color-mode(dark) {
+  code:not(:where(.not-content *)) {
+    background-color: var(--sl-color-gray-5);
+  }
+}
+
+/*
 code {
   background: $db-khaki-100;
 
@@ -80,6 +93,7 @@ code.language-mermaid {
     color: $yellow-100;
   }
 }
+*/
 
 // Math styling
 .math-block {
@@ -108,4 +122,141 @@ img.diagram {
  
 img.diagram-kroki-mermaid {
   background: $white;
+}
+
+// Source: https://www.veriphor.com/articles/code-block-line-numbers/
+
+/* Applies when there are no line numbers, or when line numbers are inline. */
+.highlight > pre {
+  padding: 0.875rem 1rem;
+}
+
+/* Applies when line numbers are in a table cell. */
+.highlight div {
+  padding: 0;
+}
+
+/* Applies to all. */
+// .highlight div,
+// .highlight > pre,
+.highlight > .chroma {
+  overflow-x: auto;
+
+  /* add border-radius and box-shadow here */
+}
+
+/* Applies when using an external style sheet */
+.highlight .chroma .lntable .lnt,
+.highlight .chroma .lntable .hl {
+  display: flex;
+}
+
+/* Applies when highlihting using table */
+.chroma .lntd:first-child {
+  padding: 0;
+
+  .lnt {
+    padding-left: 1rem;
+  }
+}
+
+.chroma .lntd:nth-child(2) {
+  padding: 0;
+}
+
+/* Applies when using an external style sheet */
+.highlight .chroma .lntable .lntd + .lntd {
+  width: 100%;
+}
+
+/* Applies when line numbers are inline */
+.chroma .ln {
+  padding: 0 0.5rem 0 0;
+}
+
+@include color-mode(dark) {
+  .chroma .ln {
+    padding: 0 0.5em 0 0;
+  }
+}
+
+/* LineTableTD */
+.chroma .lntd pre {
+  padding: 1rem 0;
+  margin-bottom: 0;
+}
+
+.highlight > .chroma::-webkit-scrollbar,
+.highlight > .chroma::-webkit-scrollbar-track {
+  background-color: inherit;
+  border-radius: 1px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0
+}
+
+.highlight > .chroma::-webkit-scrollbar-thumb {
+  background-color: #dddee0;
+  border: 4px solid transparent;
+  background-clip: content-box;
+  border-radius: 10px
+}
+
+.highlight > .chroma::-webkit-scrollbar-thumb:hover {
+  background-color: #9d9e9f;
+}
+
+@include color-mode(dark) {
+  .highlight > .chroma::-webkit-scrollbar-thumb {
+    background-color: #ffffff17;
+  }
+
+  .highlight > .chroma::-webkit-scrollbar-thumb:hover {
+    background-color: #ffffff49;
+  }
+}
+
+.highlight > .chroma {
+  border: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+}
+
+/*
+.chroma .hl {
+  background-color: #0000001a
+}
+*/
+
+.chroma .hl {
+  border-inline-start: 0.15rem solid #00000055;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  padding-left: 1rem;
+  padding-right: 1rem; 
+
+  .ln {
+    margin-left: -0.15rem;
+  }
+}
+
+@include color-mode(dark) {
+  .highlight > .chroma {
+    border: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+  }
+
+  /*
+  .chroma .hl {
+    background-color: #ffffff17;
+  }
+  */
+
+  .chroma .hl {
+    border-inline-start: 0.15rem solid #ffffff40;
+    margin-left: -1rem;
+    margin-right: -1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  
+    .ln {
+      margin-left: -0.15rem;
+    }
+  }
 }

--- a/layouts/_default/_markup/render-codeblock-kroki.html
+++ b/layouts/_default/_markup/render-codeblock-kroki.html
@@ -1,0 +1,109 @@
+{{- /* Last modified: 2023-06-30T12:24:14-07:00 */}}
+
+{{- /*
+Copyright 2023 Veriphor LLC
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+*/}}
+
+{{- /*
+Renders an SVG image of a diagram from a textual description using the Kroki service.
+
+References:
+
+- https://kroki.io/
+- https://kroki.io/#examples
+
+@context {map} Attributes The markdown attributes from the info string.
+@context {string} Inner The content between the leading and trailing code fences, excluding the info string.
+@context {map} Options The highlighting options from the info string.
+@context {int} Ordinal The zero-based ordinal of the code block on the page.
+@context {page} Page A reference to the page containing the code block.
+@context {text.Position} Position The position of the code block within the page content.
+@context {string} Type The first word of the info string.
+
+@param {string} Attributes.type The type of diagram to render
+
+@returns {template.html}
+*/}}
+
+{{- /* Initialize. */}}
+{{- $renderHookName := "kroki" }}
+
+{{- /* Verify minimum required version. */}}
+{{- $minHugoVersion := "0.114.0" }}
+{{- if lt hugo.Version $minHugoVersion }}
+  {{- errorf "The %q code block render hook requires Hugo v%s or later." $renderHookName $minHugoVersion }}
+{{- end }}
+
+{{- /* Get context. */}}
+{{- $attrs := .Attributes }}
+{{- $inner := trim .Inner "\n\r" }}
+{{- $ordinal := .Ordinal }}
+{{- $position := .Position }}
+
+{{- /* Initialize. */}}
+{{- $apiEndpoint := "https://kroki.io/" }}
+{{- $diagramType := $attrs.type | lower }}
+
+{{- /* Validate diagram type. */}}
+{{- $supportedTypes := slice
+  "actdiag" "blockdiag" "bpmn" "bytefield" "ditaa" "d2" "dbml" "erd" "graphviz"
+  "mermaid" "nomnoml" "nwdiag" "packetdiag" "pikchr" "plantuml" "rackdiag"
+  "seqdiag" "structurizr" "svgbob" "umlet" "vega" "vegalite" "wavedrom"
+  "wireviz"
+}}
+{{- $typesDelimited := delimit $supportedTypes ", " ", and " }}
+{{- if not (in $supportedTypes $diagramType) }}
+  {{- errorf "The %q code block render hook does not support diagram type %q. Valid types are %s. See %s" $renderHookName $attrs.type $typesDelimited $position }}
+{{- end }}
+
+{{- /* Determine class attribute. */}}
+{{- $class := printf "diagram diagram-kroki diagram-kroki-%s" $diagramType }}
+{{- with $attrs.class }}
+  {{- $class = printf "%s %s" $class . }}
+{{- end }}
+
+{{- /* Determine id attribute. */}}
+{{- $id := printf "h-rh-cb-kroki-%d" $ordinal }}
+{{- with $attrs.id }}
+  {{- $id = . }}
+{{- end }}
+
+{{- /* Merge class and id attributes. */}}
+{{- $attrs = merge $attrs (dict "class" $class "id" $id "alt" "diagram") }}
+
+{{- /* Get diagram. */}}
+{{- $body := dict "diagram_source" $inner "diagram_type" $diagramType "output_format" "SVG" | jsonify }}
+{{- $opts := dict "method" "post" "body" $body }}
+{{- with resources.GetRemote $apiEndpoint $opts }}
+  {{- with .Err }}
+    {{- errorf "The %q code block render hook was unable to get the remote diagram. See %s. %s" $renderHookName $position . }}
+  {{- else }}
+    {{- $attrs = merge $attrs (dict "src" .RelPermalink) }}
+  {{- end }}
+{{- else }}
+  {{- errorf "The %q code block render hook was unable to get the remote diagram. See %s" $renderHookName $position }}
+{{- end }}
+
+{{- /* Render. */}}
+<img
+  {{- range $k, $v := $attrs }}
+    {{- if not (eq $k "type") }}
+      {{- if $v }}
+        {{- printf " %s=%q" $k (string $v) | safeHTMLAttr }}
+      {{- end }}
+    {{- end }}
+  {{- end -}}
+>
+{{- /**/ -}}


### PR DESCRIPTION
## Summary

Use a fenced code block to embed an SVG image of a diagram using the free [Kroki](https://kroki.io/) service.

## Basic example

- [Diagrams](https://www.veriphor.com/articles/diagrams/)

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
