### PR TITLE
Tweak language selector

### DIFF
--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -165,7 +165,6 @@ body .toggle-light {
 
 .dropdown-caret {
   margin-left: -0.1875rem;
-  margin-right: -0.3125rem;
 }
 
 .dropdown-menu .dropdown-item.untranslated {

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -145,8 +145,7 @@
 }
 
 span#doks-language-current {
-  margin-left: 0.2rem;
-  margin-right: 0.1rem;
+  margin-left: 0.1rem;
 }
 
 button#doks-languages {

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -163,7 +163,7 @@
                 <path d="M12 20l4 -9l4 9"></path>
                 <path d="M19.1 18h-6.2"></path>
               </svg>
-              {{- /* trim preceding whitespace */}}<span id="doks-language-current"></span>{{ .Site.Language.LanguageName }}</span>{{/* trim subsequent whitespace */ -}}
+              <span id="doks-language-current">{{ .Site.Language.LanguageName }}</span>
               <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-chevron-down" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
                 <path d="M6 9l6 6l6 -6"></path>


### PR DESCRIPTION
## Summary

Fix HTML (spurious closing div tag) and tweak SCSS of the language selector. This cleanes up after myself in https://github.com/gethyas/doks-core/pull/62 (sorry for that).

## Basic example

Before: 
![Screenshot 2023-12-13 at 23-46-54 VoteLog](https://github.com/gethyas/doks-core/assets/20040931/5f103b73-5128-4328-9a94-fa127544a651)

After:
![Screenshot 2023-12-13 at 23-47-45 VoteLog](https://github.com/gethyas/doks-core/assets/20040931/1048049c-3ef3-470f-83d5-7d12c890fecb)

## Motivation

Correctness and aesthetics.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
