### PR TITLE
Figcaption

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -2,5 +2,7 @@ assets/scss/common/_colors.scss
 assets/scss/common/_syntax.scss
 assets/scss/common/_variables.scss
 assets/scss/common/_variables-dark.scss
+assets/scss/components/_callouts.scss
+assets/scss/components/_expressive-code.scss
 assets/scss/vendor
 node_modules

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,6 +12,7 @@
     "alpha-value-notation": null,
     "scss/no-global-function-names": null,
     "selector-id-pattern": null,
+    "custom-property-pattern": null,
     "at-rule-no-unknown": [
       true,
       {

--- a/assets/js/clipboard.js
+++ b/assets/js/clipboard.js
@@ -14,10 +14,10 @@ import Clipboard from 'clipboard';
   for (var i = 0; i < cb.length; ++ i)
   {
     var element = cb[i];
-    element.insertAdjacentHTML('afterbegin', '<div class="clipboard"><button class="btn btn-clipboard" aria-label="Clipboard button"></button></div>');
+    element.insertAdjacentHTML('afterbegin', '<div class="copy"><button title="Copy to clipboard" class="btn-copy" aria-label="Clipboard button"><div></div></button></div>');
   }
 
-  var clipboard = new Clipboard('.btn-clipboard', {
+  var clipboard = new Clipboard('.btn-copy', {
 
     target: function(trigger) {
       return trigger.parentNode.nextElementSibling;

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -69,6 +69,7 @@
 @import "components/alerts";
 @import "components/buttons";
 @import "components/callouts";
+@import "components/expressive-code";
 @import "components/code";
 @import "components/comments";
 @import "components/details";

--- a/assets/scss/common/_colors.scss
+++ b/assets/scss/common/_colors.scss
@@ -39,6 +39,19 @@ $db-purple-300: #5d2f86;
 /* Vermilion */
 $db-vermilion-100: #e55235;
 
+:root[data-bs-theme=light],
+[data-bs-theme=light] ::backdrop {
+--sl-color-white: hsl(224, 10%, 10%);
+--sl-color-gray-1: hsl(224, 14%, 16%);
+--sl-color-gray-2: hsl(224, 10%, 23%);
+--sl-color-gray-3: hsl(224, 7%, 36%);
+--sl-color-gray-4: hsl(224, 6%, 56%);
+--sl-color-gray-5: hsl(224, 6%, 77%);
+--sl-color-gray-6: hsl(224, 20%, 94%);
+--sl-color-gray-7: hsl(224, 19%, 97%);
+--sl-color-black: hsl(0, 0%, 100%);
+}
+
 // Dark mode
 
 :root,

--- a/assets/scss/common/_colors.scss
+++ b/assets/scss/common/_colors.scss
@@ -147,3 +147,80 @@ $db-vermilion-100: #e55235;
   --purple-hsl: 255, 60%, 60%;
   --overlay-blurple: hsla(var(--purple-hsl), .2)
 }
+
+:root {
+  --ec-brdRad: 0px;
+  --ec-brdWd: 1px;
+  --ec-brdCol: 
+color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+  --ec-codeFontFml: var(--__sl-font-mono);
+  --ec-codeFontSize: var(--sl-text-code);
+  --ec-codeFontWg: 400;
+  --ec-codeLineHt: var(--sl-line-height);
+  --ec-codePadBlk: 0.75rem;
+  --ec-codePadInl: 1rem;
+  --ec-codeBg: #011627;
+  --ec-codeFg: #d6deeb;
+  --ec-codeSelBg: #1d3b53;
+  --ec-uiFontFml: var(--__sl-font);
+  --ec-uiFontSize: 0.9rem;
+  --ec-uiFontWg: 400;
+  --ec-uiLineHt: 1.65;
+  --ec-uiPadBlk: 0.25rem;
+  --ec-uiPadInl: 1rem;
+  --ec-uiSelBg: #234d708c;
+  --ec-uiSelFg: #ffffff;
+  --ec-focusBrd: #122d42;
+  --ec-sbThumbCol: #ffffff17;
+  --ec-sbThumbHoverCol: #ffffff49;
+  --ec-tm-lineMarkerAccentMarg: 0rem;
+  --ec-tm-lineMarkerAccentWd: 0.15rem;
+  --ec-tm-lineDiffIndMargLeft: 0.25rem;
+  --ec-tm-inlMarkerBrdWd: 1.5px;
+  --ec-tm-inlMarkerBrdRad: 0.2rem;
+  --ec-tm-inlMarkerPad: 0.15rem;
+  --ec-tm-insDiffIndContent: '+';
+  --ec-tm-delDiffIndContent: '-';
+  --ec-tm-markBg: #ffffff17;
+  --ec-tm-markBrdCol: #ffffff40;
+  --ec-tm-insBg: #1e571599;
+  --ec-tm-insBrdCol: #487f3bd0;
+  --ec-tm-insDiffIndCol: #79b169d0;
+  --ec-tm-delBg: #862d2799;
+  --ec-tm-delBrdCol: #b4554bd0;
+  --ec-tm-delDiffIndCol: #ed8779d0;
+  --ec-frm-shdCol: #011627;
+  --ec-frm-frameBoxShdCssVal: none;
+  --ec-frm-edActTabBg: var(--sl-color-gray-6);
+  --ec-frm-edActTabFg: var(--sl-color-text);
+  --ec-frm-edActTabBrdCol: transparent;
+  --ec-frm-edActTabIndHt: 1px;
+  --ec-frm-edActTabIndTopCol: var(--sl-color-accent-high);
+  --ec-frm-edActTabIndBtmCol: transparent;
+  --ec-frm-edTabsMargInlStart: 0;
+  --ec-frm-edTabsMargBlkStart: 0;
+  --ec-frm-edTabBrdRad: 0px;
+  --ec-frm-edTabBarBg: var(--sl-color-black);
+  --ec-frm-edTabBarBrdCol: 
+color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+  --ec-frm-edTabBarBrdBtmCol: 
+color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+  --ec-frm-edBg: var(--sl-color-gray-6);
+  --ec-frm-trmTtbDotsFg: 
+color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+  --ec-frm-trmTtbDotsOpa: 0.75;
+  --ec-frm-trmTtbBg: var(--sl-color-black);
+  --ec-frm-trmTtbFg: var(--sl-color-text);
+  --ec-frm-trmTtbBrdBtmCol: 
+color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+  --ec-frm-trmBg: var(--sl-color-gray-6);
+  --ec-frm-inlBtnFg: var(--sl-color-text);
+  --ec-frm-inlBtnBg: var(--sl-color-text);
+  --ec-frm-inlBtnBgIdleOpa: 0;
+  --ec-frm-inlBtnBgHoverOrFocusOpa: 0.2;
+  --ec-frm-inlBtnBgActOpa: 0.3;
+  --ec-frm-inlBtnBrd: var(--sl-color-text);
+  --ec-frm-inlBtnBrdOpa: 0.4;
+  --ec-frm-tooltipSuccessBg: #158744;
+  --ec-frm-tooltipSuccessFg: white;
+}

--- a/assets/scss/common/_dark.scss
+++ b/assets/scss/common/_dark.scss
@@ -297,6 +297,7 @@ body.home .navbar {
   border-top: 1px solid $border-dark;
 }
 
+/*
 pre code::-webkit-scrollbar-thumb {
   background: $gray-400;
 }
@@ -314,6 +315,7 @@ pre code:hover {
 pre code::-webkit-scrollbar-thumb:hover {
   background: $gray-500;
 }
+*/
 
 blockquote {
   border-left: 3px solid $border-dark;

--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -471,3 +471,8 @@ hr {
     border-color: var(--sl-color-gray-3);
   }
 }
+
+// Fix for overflowing code block
+.container-fw {
+  min-width: 0;
+}

--- a/assets/scss/common/_syntax.scss
+++ b/assets/scss/common/_syntax.scss
@@ -1,14 +1,17 @@
-// Light mode: github
+// Light mode: github based
 
-/* Background */ .bg { background-color: #ffffff; }
-/* PreWrapper */ .chroma { background-color: #ffffff; }
+.highlight > .chroma { border: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 25%); }
+/* Background */ .bg { background-color: var(--sl-color-gray-7); }
+/* PreWrapper */ .chroma { background-color: var(--sl-color-gray-7); }
 /* Other */ .chroma .x {  }
 /* Error */ .chroma .err { color: inherit }
 /* CodeLine */ .chroma .cl {  }
 /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-/* LineHighlight */ .chroma .hl { background-color: #ffffcc }
+/* LineHighlight */ .chroma .hl { background-color: #0000001a }
+.chroma .lntd:first-child .hl { border-inline-start: 0.15rem solid #00000055;; }
+.chroma .lntd:first-child .hl .lnt { margin-left: -0.15rem }
 /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* Line */ .chroma .line { display: flex; }
@@ -87,18 +90,21 @@
 /* GenericUnderline */ .chroma .gl { text-decoration: underline }
 /* TextWhitespace */ .chroma .w { color: #bbbbbb }
 
-// Dark mode: github-dark
+// Dark mode: github-dark based
 
 @include color-mode(dark) {
-  /* Background */ .bg { color: #c9d1d9; background-color: #0d1117; }
-  /* PreWrapper */ .chroma { color: #c9d1d9; background-color: #0d1117; }
+  .highlight > .chroma { border: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 25%); }
+  /* Background */ .bg { color: #c9d1d9; background-color: var(--sl-color-gray-6); }
+  /* PreWrapper */ .chroma { color: #c9d1d9; background-color: var(--sl-color-gray-6); }
   /* Other */ .chroma .x {  }
   /* Error */ .chroma .err { color: inherit }
   /* CodeLine */ .chroma .cl {  }
   /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
   /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
   /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-  /* LineHighlight */ .chroma .hl { background-color: #ffffcc }
+  /* LineHighlight */ .chroma .hl { background-color: #ffffff17; }
+  .chroma .lntd:first-child .hl { border-inline-start: 0.15rem solid #ffffff40; }
+  .chroma .lntd:first-child .hl .lnt { margin-left: -0.15rem }
   /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #64686c }
   /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
   /* Line */ .chroma .line { display: flex; }

--- a/assets/scss/common/_syntax.scss
+++ b/assets/scss/common/_syntax.scss
@@ -3,12 +3,12 @@
 /* Background */ .bg { background-color: #ffffff; }
 /* PreWrapper */ .chroma { background-color: #ffffff; }
 /* Other */ .chroma .x {  }
-/* Error */ .chroma .err { color: inherit }
+/* Error */ .chroma .err { color: #a61717; background-color: #e3d2d2 }
 /* CodeLine */ .chroma .cl {  }
 /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-/* LineHighlight */ .chroma .hl { background-color: #ffffcc }
+/* LineHighlight */ .chroma .hl { background-color: #e5e5e5 }
 /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* Line */ .chroma .line { display: flex; }
@@ -75,7 +75,7 @@
 /* CommentPreprocFile */ .chroma .cpf { color: #999999; font-weight: bold; font-style: italic }
 /* Generic */ .chroma .g {  }
 /* GenericDeleted */ .chroma .gd { color: #000000; background-color: #ffdddd }
-/* GenericEmph */ .chroma .ge { color: inherit; font-style: italic }
+/* GenericEmph */ .chroma .ge { color: #000000; font-style: italic }
 /* GenericError */ .chroma .gr { color: #aa0000 }
 /* GenericHeading */ .chroma .gh { color: #999999 }
 /* GenericInserted */ .chroma .gi { color: #000000; background-color: #ddffdd }
@@ -87,93 +87,95 @@
 /* GenericUnderline */ .chroma .gl { text-decoration: underline }
 /* TextWhitespace */ .chroma .w { color: #bbbbbb }
 
+
 // Dark mode: github-dark
 
 @include color-mode(dark) {
-  /* Background */ .bg { color: #c9d1d9; background-color: #0d1117; }
-  /* PreWrapper */ .chroma { color: #c9d1d9; background-color: #0d1117; }
-  /* Other */ .chroma .x {  }
-  /* Error */ .chroma .err { color: inherit }
-  /* CodeLine */ .chroma .cl {  }
-  /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
-  /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
-  /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-  /* LineHighlight */ .chroma .hl { background-color: #ffffcc }
-  /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #64686c }
-  /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
-  /* Line */ .chroma .line { display: flex; }
-  /* Keyword */ .chroma .k { color: #ff7b72 }
-  /* KeywordConstant */ .chroma .kc { color: #79c0ff }
-  /* KeywordDeclaration */ .chroma .kd { color: #ff7b72 }
-  /* KeywordNamespace */ .chroma .kn { color: #ff7b72 }
-  /* KeywordPseudo */ .chroma .kp { color: #79c0ff }
-  /* KeywordReserved */ .chroma .kr { color: #ff7b72 }
-  /* KeywordType */ .chroma .kt { color: #ff7b72 }
-  /* Name */ .chroma .n {  }
-  /* NameAttribute */ .chroma .na { color: #d2a8ff }
-  /* NameBuiltin */ .chroma .nb {  }
-  /* NameBuiltinPseudo */ .chroma .bp {  }
-  /* NameClass */ .chroma .nc { color: #f0883e; font-weight: bold }
-  /* NameConstant */ .chroma .no { color: #79c0ff; font-weight: bold }
-  /* NameDecorator */ .chroma .nd { color: #d2a8ff; font-weight: bold }
-  /* NameEntity */ .chroma .ni { color: #ffa657 }
-  /* NameException */ .chroma .ne { color: #f0883e; font-weight: bold }
-  /* NameFunction */ .chroma .nf { color: #d2a8ff; font-weight: bold }
-  /* NameFunctionMagic */ .chroma .fm {  }
-  /* NameLabel */ .chroma .nl { color: #79c0ff; font-weight: bold }
-  /* NameNamespace */ .chroma .nn { color: #ff7b72 }
-  /* NameOther */ .chroma .nx {  }
-  /* NameProperty */ .chroma .py { color: #79c0ff }
-  /* NameTag */ .chroma .nt { color: #7ee787 }
-  /* NameVariable */ .chroma .nv { color: #79c0ff }
-  /* NameVariableClass */ .chroma .vc {  }
-  /* NameVariableGlobal */ .chroma .vg {  }
-  /* NameVariableInstance */ .chroma .vi {  }
-  /* NameVariableMagic */ .chroma .vm {  }
-  /* Literal */ .chroma .l { color: #a5d6ff }
-  /* LiteralDate */ .chroma .ld { color: #79c0ff }
-  /* LiteralString */ .chroma .s { color: #a5d6ff }
-  /* LiteralStringAffix */ .chroma .sa { color: #79c0ff }
-  /* LiteralStringBacktick */ .chroma .sb { color: #a5d6ff }
-  /* LiteralStringChar */ .chroma .sc { color: #a5d6ff }
-  /* LiteralStringDelimiter */ .chroma .dl { color: #79c0ff }
-  /* LiteralStringDoc */ .chroma .sd { color: #a5d6ff }
-  /* LiteralStringDouble */ .chroma .s2 { color: #a5d6ff }
-  /* LiteralStringEscape */ .chroma .se { color: #79c0ff }
-  /* LiteralStringHeredoc */ .chroma .sh { color: #79c0ff }
-  /* LiteralStringInterpol */ .chroma .si { color: #a5d6ff }
-  /* LiteralStringOther */ .chroma .sx { color: #a5d6ff }
-  /* LiteralStringRegex */ .chroma .sr { color: #79c0ff }
-  /* LiteralStringSingle */ .chroma .s1 { color: #a5d6ff }
-  /* LiteralStringSymbol */ .chroma .ss { color: #a5d6ff }
-  /* LiteralNumber */ .chroma .m { color: #a5d6ff }
-  /* LiteralNumberBin */ .chroma .mb { color: #a5d6ff }
-  /* LiteralNumberFloat */ .chroma .mf { color: #a5d6ff }
-  /* LiteralNumberHex */ .chroma .mh { color: #a5d6ff }
-  /* LiteralNumberInteger */ .chroma .mi { color: #a5d6ff }
-  /* LiteralNumberIntegerLong */ .chroma .il { color: #a5d6ff }
-  /* LiteralNumberOct */ .chroma .mo { color: #a5d6ff }
-  /* Operator */ .chroma .o { color: inherit; font-weight: bold }
-  /* OperatorWord */ .chroma .ow { color: #ff7b72; font-weight: bold }
-  /* Punctuation */ .chroma .p {  }
-  /* Comment */ .chroma .c { color: #8b949e; font-style: italic }
-  /* CommentHashbang */ .chroma .ch { color: #8b949e; font-style: italic }
-  /* CommentMultiline */ .chroma .cm { color: #8b949e; font-style: italic }
-  /* CommentSingle */ .chroma .c1 { color: #8b949e; font-style: italic }
-  /* CommentSpecial */ .chroma .cs { color: #8b949e; font-weight: bold; font-style: italic }
-  /* CommentPreproc */ .chroma .cp { color: #8b949e; font-weight: bold; font-style: italic }
-  /* CommentPreprocFile */ .chroma .cpf { color: #8b949e; font-weight: bold; font-style: italic }
-  /* Generic */ .chroma .g {  }
-  /* GenericDeleted */ .chroma .gd { color: #ffa198; background-color: #490202 }
-  /* GenericEmph */ .chroma .ge { font-style: italic }
-  /* GenericError */ .chroma .gr { color: #ffa198 }
-  /* GenericHeading */ .chroma .gh { color: #79c0ff; font-weight: bold }
-  /* GenericInserted */ .chroma .gi { color: #56d364; background-color: #0f5323 }
-  /* GenericOutput */ .chroma .go { color: #8b949e }
-  /* GenericPrompt */ .chroma .gp { color: #8b949e }
-  /* GenericStrong */ .chroma .gs { font-weight: bold }
-  /* GenericSubheading */ .chroma .gu { color: #79c0ff }
-  /* GenericTraceback */ .chroma .gt { color: #ff7b72 }
-  /* GenericUnderline */ .chroma .gl { text-decoration: underline }
-  /* TextWhitespace */ .chroma .w { color: #6e7681 }
+/* Background */ .bg { color: #e6edf3; background-color: #0d1117; }
+/* PreWrapper */ .chroma { color: #e6edf3; background-color: #0d1117; }
+/* Other */ .chroma .x {  }
+/* Error */ .chroma .err { color: #f85149 }
+/* CodeLine */ .chroma .cl {  }
+/* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
+/* LineHighlight */ .chroma .hl { color: #6e7681 }
+/* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #737679 }
+/* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
+/* Line */ .chroma .line { display: flex; }
+/* Keyword */ .chroma .k { color: #ff7b72 }
+/* KeywordConstant */ .chroma .kc { color: #79c0ff }
+/* KeywordDeclaration */ .chroma .kd { color: #ff7b72 }
+/* KeywordNamespace */ .chroma .kn { color: #ff7b72 }
+/* KeywordPseudo */ .chroma .kp { color: #79c0ff }
+/* KeywordReserved */ .chroma .kr { color: #ff7b72 }
+/* KeywordType */ .chroma .kt { color: #ff7b72 }
+/* Name */ .chroma .n {  }
+/* NameAttribute */ .chroma .na {  }
+/* NameBuiltin */ .chroma .nb {  }
+/* NameBuiltinPseudo */ .chroma .bp {  }
+/* NameClass */ .chroma .nc { color: #f0883e; font-weight: bold }
+/* NameConstant */ .chroma .no { color: #79c0ff; font-weight: bold }
+/* NameDecorator */ .chroma .nd { color: #d2a8ff; font-weight: bold }
+/* NameEntity */ .chroma .ni { color: #ffa657 }
+/* NameException */ .chroma .ne { color: #f0883e; font-weight: bold }
+/* NameFunction */ .chroma .nf { color: #d2a8ff; font-weight: bold }
+/* NameFunctionMagic */ .chroma .fm {  }
+/* NameLabel */ .chroma .nl { color: #79c0ff; font-weight: bold }
+/* NameNamespace */ .chroma .nn { color: #ff7b72 }
+/* NameOther */ .chroma .nx {  }
+/* NameProperty */ .chroma .py { color: #79c0ff }
+/* NameTag */ .chroma .nt { color: #7ee787 }
+/* NameVariable */ .chroma .nv { color: #79c0ff }
+/* NameVariableClass */ .chroma .vc {  }
+/* NameVariableGlobal */ .chroma .vg {  }
+/* NameVariableInstance */ .chroma .vi {  }
+/* NameVariableMagic */ .chroma .vm {  }
+/* Literal */ .chroma .l { color: #a5d6ff }
+/* LiteralDate */ .chroma .ld { color: #79c0ff }
+/* LiteralString */ .chroma .s { color: #a5d6ff }
+/* LiteralStringAffix */ .chroma .sa { color: #79c0ff }
+/* LiteralStringBacktick */ .chroma .sb { color: #a5d6ff }
+/* LiteralStringChar */ .chroma .sc { color: #a5d6ff }
+/* LiteralStringDelimiter */ .chroma .dl { color: #79c0ff }
+/* LiteralStringDoc */ .chroma .sd { color: #a5d6ff }
+/* LiteralStringDouble */ .chroma .s2 { color: #a5d6ff }
+/* LiteralStringEscape */ .chroma .se { color: #79c0ff }
+/* LiteralStringHeredoc */ .chroma .sh { color: #79c0ff }
+/* LiteralStringInterpol */ .chroma .si { color: #a5d6ff }
+/* LiteralStringOther */ .chroma .sx { color: #a5d6ff }
+/* LiteralStringRegex */ .chroma .sr { color: #79c0ff }
+/* LiteralStringSingle */ .chroma .s1 { color: #a5d6ff }
+/* LiteralStringSymbol */ .chroma .ss { color: #a5d6ff }
+/* LiteralNumber */ .chroma .m { color: #a5d6ff }
+/* LiteralNumberBin */ .chroma .mb { color: #a5d6ff }
+/* LiteralNumberFloat */ .chroma .mf { color: #a5d6ff }
+/* LiteralNumberHex */ .chroma .mh { color: #a5d6ff }
+/* LiteralNumberInteger */ .chroma .mi { color: #a5d6ff }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #a5d6ff }
+/* LiteralNumberOct */ .chroma .mo { color: #a5d6ff }
+/* Operator */ .chroma .o { color: #ff7b72; font-weight: bold }
+/* OperatorWord */ .chroma .ow { color: #ff7b72; font-weight: bold }
+/* Punctuation */ .chroma .p {  }
+/* Comment */ .chroma .c { color: #8b949e; font-style: italic }
+/* CommentHashbang */ .chroma .ch { color: #8b949e; font-style: italic }
+/* CommentMultiline */ .chroma .cm { color: #8b949e; font-style: italic }
+/* CommentSingle */ .chroma .c1 { color: #8b949e; font-style: italic }
+/* CommentSpecial */ .chroma .cs { color: #8b949e; font-weight: bold; font-style: italic }
+/* CommentPreproc */ .chroma .cp { color: #8b949e; font-weight: bold; font-style: italic }
+/* CommentPreprocFile */ .chroma .cpf { color: #8b949e; font-weight: bold; font-style: italic }
+/* Generic */ .chroma .g {  }
+/* GenericDeleted */ .chroma .gd { color: #ffa198; background-color: #490202 }
+/* GenericEmph */ .chroma .ge { font-style: italic }
+/* GenericError */ .chroma .gr { color: #ffa198 }
+/* GenericHeading */ .chroma .gh { color: #79c0ff; font-weight: bold }
+/* GenericInserted */ .chroma .gi { color: #56d364; background-color: #0f5323 }
+/* GenericOutput */ .chroma .go { color: #8b949e }
+/* GenericPrompt */ .chroma .gp { color: #8b949e }
+/* GenericStrong */ .chroma .gs { font-weight: bold }
+/* GenericSubheading */ .chroma .gu { color: #79c0ff }
+/* GenericTraceback */ .chroma .gt { color: #ff7b72 }
+/* GenericUnderline */ .chroma .gl { text-decoration: underline }
+/* TextWhitespace */ .chroma .w { color: #6e7681 }
+
 }

--- a/assets/scss/common/_syntax.scss
+++ b/assets/scss/common/_syntax.scss
@@ -3,12 +3,12 @@
 /* Background */ .bg { background-color: #ffffff; }
 /* PreWrapper */ .chroma { background-color: #ffffff; }
 /* Other */ .chroma .x {  }
-/* Error */ .chroma .err { color: #a61717; background-color: #e3d2d2 }
+/* Error */ .chroma .err { color: inherit }
 /* CodeLine */ .chroma .cl {  }
 /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-/* LineHighlight */ .chroma .hl { background-color: #e5e5e5 }
+/* LineHighlight */ .chroma .hl { background-color: #ffffcc }
 /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* Line */ .chroma .line { display: flex; }
@@ -75,7 +75,7 @@
 /* CommentPreprocFile */ .chroma .cpf { color: #999999; font-weight: bold; font-style: italic }
 /* Generic */ .chroma .g {  }
 /* GenericDeleted */ .chroma .gd { color: #000000; background-color: #ffdddd }
-/* GenericEmph */ .chroma .ge { color: #000000; font-style: italic }
+/* GenericEmph */ .chroma .ge { color: inherit; font-style: italic }
 /* GenericError */ .chroma .gr { color: #aa0000 }
 /* GenericHeading */ .chroma .gh { color: #999999 }
 /* GenericInserted */ .chroma .gi { color: #000000; background-color: #ddffdd }
@@ -87,95 +87,93 @@
 /* GenericUnderline */ .chroma .gl { text-decoration: underline }
 /* TextWhitespace */ .chroma .w { color: #bbbbbb }
 
-
 // Dark mode: github-dark
 
 @include color-mode(dark) {
-/* Background */ .bg { color: #e6edf3; background-color: #0d1117; }
-/* PreWrapper */ .chroma { color: #e6edf3; background-color: #0d1117; }
-/* Other */ .chroma .x {  }
-/* Error */ .chroma .err { color: #f85149 }
-/* CodeLine */ .chroma .cl {  }
-/* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
-/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
-/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-/* LineHighlight */ .chroma .hl { color: #6e7681 }
-/* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #737679 }
-/* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
-/* Line */ .chroma .line { display: flex; }
-/* Keyword */ .chroma .k { color: #ff7b72 }
-/* KeywordConstant */ .chroma .kc { color: #79c0ff }
-/* KeywordDeclaration */ .chroma .kd { color: #ff7b72 }
-/* KeywordNamespace */ .chroma .kn { color: #ff7b72 }
-/* KeywordPseudo */ .chroma .kp { color: #79c0ff }
-/* KeywordReserved */ .chroma .kr { color: #ff7b72 }
-/* KeywordType */ .chroma .kt { color: #ff7b72 }
-/* Name */ .chroma .n {  }
-/* NameAttribute */ .chroma .na {  }
-/* NameBuiltin */ .chroma .nb {  }
-/* NameBuiltinPseudo */ .chroma .bp {  }
-/* NameClass */ .chroma .nc { color: #f0883e; font-weight: bold }
-/* NameConstant */ .chroma .no { color: #79c0ff; font-weight: bold }
-/* NameDecorator */ .chroma .nd { color: #d2a8ff; font-weight: bold }
-/* NameEntity */ .chroma .ni { color: #ffa657 }
-/* NameException */ .chroma .ne { color: #f0883e; font-weight: bold }
-/* NameFunction */ .chroma .nf { color: #d2a8ff; font-weight: bold }
-/* NameFunctionMagic */ .chroma .fm {  }
-/* NameLabel */ .chroma .nl { color: #79c0ff; font-weight: bold }
-/* NameNamespace */ .chroma .nn { color: #ff7b72 }
-/* NameOther */ .chroma .nx {  }
-/* NameProperty */ .chroma .py { color: #79c0ff }
-/* NameTag */ .chroma .nt { color: #7ee787 }
-/* NameVariable */ .chroma .nv { color: #79c0ff }
-/* NameVariableClass */ .chroma .vc {  }
-/* NameVariableGlobal */ .chroma .vg {  }
-/* NameVariableInstance */ .chroma .vi {  }
-/* NameVariableMagic */ .chroma .vm {  }
-/* Literal */ .chroma .l { color: #a5d6ff }
-/* LiteralDate */ .chroma .ld { color: #79c0ff }
-/* LiteralString */ .chroma .s { color: #a5d6ff }
-/* LiteralStringAffix */ .chroma .sa { color: #79c0ff }
-/* LiteralStringBacktick */ .chroma .sb { color: #a5d6ff }
-/* LiteralStringChar */ .chroma .sc { color: #a5d6ff }
-/* LiteralStringDelimiter */ .chroma .dl { color: #79c0ff }
-/* LiteralStringDoc */ .chroma .sd { color: #a5d6ff }
-/* LiteralStringDouble */ .chroma .s2 { color: #a5d6ff }
-/* LiteralStringEscape */ .chroma .se { color: #79c0ff }
-/* LiteralStringHeredoc */ .chroma .sh { color: #79c0ff }
-/* LiteralStringInterpol */ .chroma .si { color: #a5d6ff }
-/* LiteralStringOther */ .chroma .sx { color: #a5d6ff }
-/* LiteralStringRegex */ .chroma .sr { color: #79c0ff }
-/* LiteralStringSingle */ .chroma .s1 { color: #a5d6ff }
-/* LiteralStringSymbol */ .chroma .ss { color: #a5d6ff }
-/* LiteralNumber */ .chroma .m { color: #a5d6ff }
-/* LiteralNumberBin */ .chroma .mb { color: #a5d6ff }
-/* LiteralNumberFloat */ .chroma .mf { color: #a5d6ff }
-/* LiteralNumberHex */ .chroma .mh { color: #a5d6ff }
-/* LiteralNumberInteger */ .chroma .mi { color: #a5d6ff }
-/* LiteralNumberIntegerLong */ .chroma .il { color: #a5d6ff }
-/* LiteralNumberOct */ .chroma .mo { color: #a5d6ff }
-/* Operator */ .chroma .o { color: #ff7b72; font-weight: bold }
-/* OperatorWord */ .chroma .ow { color: #ff7b72; font-weight: bold }
-/* Punctuation */ .chroma .p {  }
-/* Comment */ .chroma .c { color: #8b949e; font-style: italic }
-/* CommentHashbang */ .chroma .ch { color: #8b949e; font-style: italic }
-/* CommentMultiline */ .chroma .cm { color: #8b949e; font-style: italic }
-/* CommentSingle */ .chroma .c1 { color: #8b949e; font-style: italic }
-/* CommentSpecial */ .chroma .cs { color: #8b949e; font-weight: bold; font-style: italic }
-/* CommentPreproc */ .chroma .cp { color: #8b949e; font-weight: bold; font-style: italic }
-/* CommentPreprocFile */ .chroma .cpf { color: #8b949e; font-weight: bold; font-style: italic }
-/* Generic */ .chroma .g {  }
-/* GenericDeleted */ .chroma .gd { color: #ffa198; background-color: #490202 }
-/* GenericEmph */ .chroma .ge { font-style: italic }
-/* GenericError */ .chroma .gr { color: #ffa198 }
-/* GenericHeading */ .chroma .gh { color: #79c0ff; font-weight: bold }
-/* GenericInserted */ .chroma .gi { color: #56d364; background-color: #0f5323 }
-/* GenericOutput */ .chroma .go { color: #8b949e }
-/* GenericPrompt */ .chroma .gp { color: #8b949e }
-/* GenericStrong */ .chroma .gs { font-weight: bold }
-/* GenericSubheading */ .chroma .gu { color: #79c0ff }
-/* GenericTraceback */ .chroma .gt { color: #ff7b72 }
-/* GenericUnderline */ .chroma .gl { text-decoration: underline }
-/* TextWhitespace */ .chroma .w { color: #6e7681 }
-
+  /* Background */ .bg { color: #c9d1d9; background-color: #0d1117; }
+  /* PreWrapper */ .chroma { color: #c9d1d9; background-color: #0d1117; }
+  /* Other */ .chroma .x {  }
+  /* Error */ .chroma .err { color: inherit }
+  /* CodeLine */ .chroma .cl {  }
+  /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
+  /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+  /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
+  /* LineHighlight */ .chroma .hl { background-color: #ffffcc }
+  /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #64686c }
+  /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
+  /* Line */ .chroma .line { display: flex; }
+  /* Keyword */ .chroma .k { color: #ff7b72 }
+  /* KeywordConstant */ .chroma .kc { color: #79c0ff }
+  /* KeywordDeclaration */ .chroma .kd { color: #ff7b72 }
+  /* KeywordNamespace */ .chroma .kn { color: #ff7b72 }
+  /* KeywordPseudo */ .chroma .kp { color: #79c0ff }
+  /* KeywordReserved */ .chroma .kr { color: #ff7b72 }
+  /* KeywordType */ .chroma .kt { color: #ff7b72 }
+  /* Name */ .chroma .n {  }
+  /* NameAttribute */ .chroma .na { color: #d2a8ff }
+  /* NameBuiltin */ .chroma .nb {  }
+  /* NameBuiltinPseudo */ .chroma .bp {  }
+  /* NameClass */ .chroma .nc { color: #f0883e; font-weight: bold }
+  /* NameConstant */ .chroma .no { color: #79c0ff; font-weight: bold }
+  /* NameDecorator */ .chroma .nd { color: #d2a8ff; font-weight: bold }
+  /* NameEntity */ .chroma .ni { color: #ffa657 }
+  /* NameException */ .chroma .ne { color: #f0883e; font-weight: bold }
+  /* NameFunction */ .chroma .nf { color: #d2a8ff; font-weight: bold }
+  /* NameFunctionMagic */ .chroma .fm {  }
+  /* NameLabel */ .chroma .nl { color: #79c0ff; font-weight: bold }
+  /* NameNamespace */ .chroma .nn { color: #ff7b72 }
+  /* NameOther */ .chroma .nx {  }
+  /* NameProperty */ .chroma .py { color: #79c0ff }
+  /* NameTag */ .chroma .nt { color: #7ee787 }
+  /* NameVariable */ .chroma .nv { color: #79c0ff }
+  /* NameVariableClass */ .chroma .vc {  }
+  /* NameVariableGlobal */ .chroma .vg {  }
+  /* NameVariableInstance */ .chroma .vi {  }
+  /* NameVariableMagic */ .chroma .vm {  }
+  /* Literal */ .chroma .l { color: #a5d6ff }
+  /* LiteralDate */ .chroma .ld { color: #79c0ff }
+  /* LiteralString */ .chroma .s { color: #a5d6ff }
+  /* LiteralStringAffix */ .chroma .sa { color: #79c0ff }
+  /* LiteralStringBacktick */ .chroma .sb { color: #a5d6ff }
+  /* LiteralStringChar */ .chroma .sc { color: #a5d6ff }
+  /* LiteralStringDelimiter */ .chroma .dl { color: #79c0ff }
+  /* LiteralStringDoc */ .chroma .sd { color: #a5d6ff }
+  /* LiteralStringDouble */ .chroma .s2 { color: #a5d6ff }
+  /* LiteralStringEscape */ .chroma .se { color: #79c0ff }
+  /* LiteralStringHeredoc */ .chroma .sh { color: #79c0ff }
+  /* LiteralStringInterpol */ .chroma .si { color: #a5d6ff }
+  /* LiteralStringOther */ .chroma .sx { color: #a5d6ff }
+  /* LiteralStringRegex */ .chroma .sr { color: #79c0ff }
+  /* LiteralStringSingle */ .chroma .s1 { color: #a5d6ff }
+  /* LiteralStringSymbol */ .chroma .ss { color: #a5d6ff }
+  /* LiteralNumber */ .chroma .m { color: #a5d6ff }
+  /* LiteralNumberBin */ .chroma .mb { color: #a5d6ff }
+  /* LiteralNumberFloat */ .chroma .mf { color: #a5d6ff }
+  /* LiteralNumberHex */ .chroma .mh { color: #a5d6ff }
+  /* LiteralNumberInteger */ .chroma .mi { color: #a5d6ff }
+  /* LiteralNumberIntegerLong */ .chroma .il { color: #a5d6ff }
+  /* LiteralNumberOct */ .chroma .mo { color: #a5d6ff }
+  /* Operator */ .chroma .o { color: inherit; font-weight: bold }
+  /* OperatorWord */ .chroma .ow { color: #ff7b72; font-weight: bold }
+  /* Punctuation */ .chroma .p {  }
+  /* Comment */ .chroma .c { color: #8b949e; font-style: italic }
+  /* CommentHashbang */ .chroma .ch { color: #8b949e; font-style: italic }
+  /* CommentMultiline */ .chroma .cm { color: #8b949e; font-style: italic }
+  /* CommentSingle */ .chroma .c1 { color: #8b949e; font-style: italic }
+  /* CommentSpecial */ .chroma .cs { color: #8b949e; font-weight: bold; font-style: italic }
+  /* CommentPreproc */ .chroma .cp { color: #8b949e; font-weight: bold; font-style: italic }
+  /* CommentPreprocFile */ .chroma .cpf { color: #8b949e; font-weight: bold; font-style: italic }
+  /* Generic */ .chroma .g {  }
+  /* GenericDeleted */ .chroma .gd { color: #ffa198; background-color: #490202 }
+  /* GenericEmph */ .chroma .ge { font-style: italic }
+  /* GenericError */ .chroma .gr { color: #ffa198 }
+  /* GenericHeading */ .chroma .gh { color: #79c0ff; font-weight: bold }
+  /* GenericInserted */ .chroma .gi { color: #56d364; background-color: #0f5323 }
+  /* GenericOutput */ .chroma .go { color: #8b949e }
+  /* GenericPrompt */ .chroma .gp { color: #8b949e }
+  /* GenericStrong */ .chroma .gs { font-weight: bold }
+  /* GenericSubheading */ .chroma .gu { color: #79c0ff }
+  /* GenericTraceback */ .chroma .gt { color: #ff7b72 }
+  /* GenericUnderline */ .chroma .gl { text-decoration: underline }
+  /* TextWhitespace */ .chroma .w { color: #6e7681 }
 }

--- a/assets/scss/common/_syntax.scss
+++ b/assets/scss/common/_syntax.scss
@@ -10,8 +10,17 @@
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
 /* LineHighlight */ .chroma .hl { background-color: #0000001a }
-.chroma .lntd:first-child .hl { border-inline-start: 0.15rem solid #00000055;; }
-.chroma .lntd:first-child .hl .lnt { margin-left: -0.15rem }
+.chroma .hl {
+  border-inline-start: 0.15rem solid #00000055;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  padding-left: 1rem;
+  padding-right: 1rem; 
+
+  .ln {
+    margin-left: -0.15rem;
+  }
+}
 /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* Line */ .chroma .line { display: flex; }
@@ -103,8 +112,17 @@
   /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
   /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
   /* LineHighlight */ .chroma .hl { background-color: #ffffff17; }
-  .chroma .lntd:first-child .hl { border-inline-start: 0.15rem solid #ffffff40; }
-  .chroma .lntd:first-child .hl .lnt { margin-left: -0.15rem }
+  .chroma .hl {
+    border-inline-start: 0.15rem solid #ffffff40;
+    margin-left: -1rem;
+    margin-right: -1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  
+    .ln {
+      margin-left: -0.15rem;
+    }
+  }
   /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #64686c }
   /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
   /* Line */ .chroma .line { display: flex; }

--- a/assets/scss/components/_callouts.scss
+++ b/assets/scss/components/_callouts.scss
@@ -34,6 +34,11 @@
   }
 }
 
+// Fix for overflowing code block
+.callout-content {
+  min-width: 0;
+}
+
 // Colors
 .callout.callout-note {
   border-color: var(--sl-color-blue);

--- a/assets/scss/components/_callouts.scss
+++ b/assets/scss/components/_callouts.scss
@@ -15,10 +15,12 @@
     text-decoration: underline;
   }
 
+  /*
   code {
     background: transparent;
     color: inherit;
   }
+  */
 
   .highlight {
     background-color: rgba($black, .05);
@@ -46,13 +48,21 @@
 
   .callout-icon,
   .callout-title,
-  .callout-body {
+  .callout-body a {
     color: var(--sl-color-blue-low);
   }
 
-  code {
+  .callout-body,
+  .callout-body a:hover,
+  .callout-body a:active {
+    color: var(--sl-color-white);
+  }
+
+  /*
+  code:not(:where(.not-content *)) {
     background: tint-color($info, 80%);
   }
+  */
 }
 
 .callout.callout-tip {
@@ -61,13 +71,21 @@
 
   .callout-icon,
   .callout-title,
-  .callout-body {
+  .callout-body a {
     color: var(--sl-color-purple-low);
   }
 
-  code {
+  .callout-body,
+  .callout-body a:hover,
+  .callout-body a:active {
+    color: var(--sl-color-white);
+  }
+
+  /*
+  code:not(:where(.not-content *)) {
     background: tint-color($purple, 80%);
   }
+  */
 }
 
 .callout.callout-caution {
@@ -76,13 +94,21 @@
 
   .callout-icon,
   .callout-title,
-  .callout-body {
+  .callout-body a {
     color: var(--sl-color-orange-low);
   }
+  
+  .callout-body,
+  .callout-body a:hover,
+  .callout-body a:active {
+    color: var(--sl-color-white);
+  }
 
-  code {
+  /*
+  code:not(:where(.not-content *)) {
     background: tint-color($yellow, 80%);
   }
+  */
 }
 
 .callout.callout-danger {
@@ -91,18 +117,28 @@
 
   .callout-icon,
   .callout-title,
-  .callout-body {
+  .callout-body a {
     color: var(--sl-color-red-low);
   }
 
-  code {
+  .callout-body,
+  .callout-body a:hover,
+  .callout-body a:active {
+    color: var(--sl-color-white);
+  }
+
+  /*
+  code:not(:where(.not-content *)) {
     background: tint-color($red, 80%);
   }
+  */
 }
 
+/*
 .callout.callout-light code {
   background: var(--sl-color-gray-1);
 }
+*/
 
 @include color-mode(dark) {
   .callout {
@@ -115,12 +151,19 @@
 
     .callout-icon,
     .callout-title,
-    .callout-body {
+    .callout-body a {
       color: var(--sl-color-blue-high);
     }
 
-    code {
-      background: shade-color($info, 75%);
+    .callout-body,
+    .callout-body a:hover,
+    .callout-body a:active {
+      color: var(--sl-color-white);
+    }
+
+    code:not(:where(.not-content *)) {
+      // background: shade-color($info, 75%);
+      color: var(--ec-codeFg);
     }
   }
 
@@ -130,12 +173,19 @@
 
     .callout-icon,
     .callout-title,
-    .callout-body {
+    .callout-body a {
       color: var(--sl-color-purple-high);
     }
 
-    code {
-      background: shade-color($purple, 75%);
+    .callout-body,
+    .callout-body a:hover,
+    .callout-body a:active {
+      color: var(--sl-color-white);
+    }
+
+    code:not(:where(.not-content *)) {
+      // background: shade-color($purple, 75%);
+      color: var(--ec-codeFg);
     }
   }
 
@@ -145,12 +195,19 @@
 
     .callout-icon,
     .callout-title,
-    .callout-body {
+    .callout-body a {
       color: var(--sl-color-orange-high);
     }
 
-    code {
-      background: shade-color($yellow, 75%);
+    .callout-body,
+    .callout-body a:hover,
+    .callout-body a:active {
+      color: var(--sl-color-white);
+    }
+
+    code:not(:where(.not-content *)) {
+      // background: shade-color($yellow, 75%);
+      color: var(--ec-codeFg);
     }
   }
 
@@ -160,12 +217,19 @@
 
     .callout-icon,
     .callout-title,
-    .callout-body {
+    .callout-body a {
       color: var(--sl-color-red-high);
     }
 
-    code {
-      background: shade-color($red, 75%);
+    .callout-body,
+    .callout-body a:hover,
+    .callout-body a:active {
+      color: var(--sl-color-white);
+    }
+
+    code:not(:where(.not-content *)) {
+      // background: shade-color($red, 75%);
+      color: var(--ec-codeFg);
     }
   }
 }

--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -6,6 +6,19 @@ samp {
   font-size: $font-size-sm;
 }
 
+code:not(:where(.not-content *)) {
+  background-color: var(--sl-color-gray-6);
+  margin-block: -0.125rem;
+  padding: 0.125rem 0.375rem;
+  color: inherit;
+}
+
+@include color-mode(dark) {
+  code:not(:where(.not-content *)) {
+    background-color: var(--sl-color-gray-5);
+  }
+}
+
 /*
 code {
   background: $db-khaki-100;
@@ -92,7 +105,7 @@ code.language-mermaid {
 
 /* Applies when there are no line numbers, or when line numbers are inline. */
 .highlight > pre {
-  padding: 0.875rem 0 0.875rem 1rem;
+  padding: 0.875rem 1rem;
 }
 
 /* Applies when line numbers are in a table cell. */
@@ -105,18 +118,30 @@ code.language-mermaid {
 // .highlight > pre,
 .highlight > .chroma {
   overflow-x: auto;
+
   /* add border-radius and box-shadow here */
 }
 
-/* Applies when using an external style sheet. */
-/* https://github.com/alecthomas/chroma/issues/722 */
+/* Applies when using an external style sheet */
 .highlight .chroma .lntable .lnt,
 .highlight .chroma .lntable .hl {
   display: flex;
 }
 
-/* Applies when using an external style sheet. */
-/* https://github.com/alecthomas/chroma/issues/722 */
+/* Applies when highlihting using table */
+.chroma .lntd:first-child {
+  padding: 0;
+
+  .lnt {
+    padding-left: 1rem;
+  }
+}
+
+.chroma .lntd:nth-child(2) {
+  padding: 0;
+}
+
+/* Applies when using an external style sheet */
 .highlight .chroma .lntable .lntd + .lntd {
   width: 100%;
 }
@@ -132,22 +157,9 @@ code.language-mermaid {
   }
 }
 
-/* Applies when highlihting using table*/
-.chroma .lntd:first-child {
-  padding: 0;
-
-  .lnt {
-    padding-left: 1rem;
-  }
-}
-
-.chroma .lntd:nth-child(2) {
-  padding: 0;
-}
-
 /* LineTableTD */
 .chroma .lntd pre {
-  padding: 1rem 0 1rem;
+  padding: 1rem 0;
   margin-bottom: 0;
 }
 

--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -191,3 +191,49 @@ code.language-mermaid {
     background-color: #ffffff49;
   }
 }
+
+.highlight > .chroma {
+  border: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+}
+
+/*
+.chroma .hl {
+  background-color: #0000001a
+}
+*/
+
+.chroma .hl {
+  border-inline-start: 0.15rem solid #00000055;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  padding-left: 1rem;
+  padding-right: 1rem; 
+
+  .ln {
+    margin-left: -0.15rem;
+  }
+}
+
+@include color-mode(dark) {
+  .highlight > .chroma {
+    border: 1px solid color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+  }
+
+  /*
+  .chroma .hl {
+    background-color: #ffffff17;
+  }
+  */
+
+  .chroma .hl {
+    border-inline-start: 0.15rem solid #ffffff40;
+    margin-left: -1rem;
+    margin-right: -1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  
+    .ln {
+      margin-left: -0.15rem;
+    }
+  }
+}

--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -4,9 +4,9 @@ kbd,
 samp {
   font-family: $font-family-monospace;
   font-size: $font-size-sm;
-  border-radius: $border-radius;
 }
 
+/*
 code {
   background: $db-khaki-100;
 
@@ -80,9 +80,102 @@ code.language-mermaid {
     color: $yellow-100;
   }
 }
+*/
 
 @include color-mode(dark) {
   .math-block img {
     filter: invert(1);
+  }
+}
+
+// Source: https://www.veriphor.com/articles/code-block-line-numbers/
+
+/* Applies when there are no line numbers, or when line numbers are inline. */
+.highlight > pre {
+  padding: 0.875rem 0 0.875rem 1rem;
+}
+
+/* Applies when line numbers are in a table cell. */
+.highlight div {
+  padding: 0;
+}
+
+/* Applies to all. */
+// .highlight div,
+// .highlight > pre,
+.highlight > .chroma {
+  overflow-x: auto;
+  /* add border-radius and box-shadow here */
+}
+
+/* Applies when using an external style sheet. */
+/* https://github.com/alecthomas/chroma/issues/722 */
+.highlight .chroma .lntable .lnt,
+.highlight .chroma .lntable .hl {
+  display: flex;
+}
+
+/* Applies when using an external style sheet. */
+/* https://github.com/alecthomas/chroma/issues/722 */
+.highlight .chroma .lntable .lntd + .lntd {
+  width: 100%;
+}
+
+/* Applies when line numbers are inline */
+.chroma .ln {
+  padding: 0 0.5rem 0 0;
+}
+
+@include color-mode(dark) {
+  .chroma .ln {
+    padding: 0 0.5em 0 0;
+  }
+}
+
+/* Applies when highlihting using table*/
+.chroma .lntd:first-child {
+  padding: 0;
+
+  .lnt {
+    padding-left: 1rem;
+  }
+}
+
+.chroma .lntd:nth-child(2) {
+  padding: 0;
+}
+
+/* LineTableTD */
+.chroma .lntd pre {
+  padding: 1rem 0 1rem;
+  margin-bottom: 0;
+}
+
+.highlight > .chroma::-webkit-scrollbar,
+.highlight > .chroma::-webkit-scrollbar-track {
+  background-color: inherit;
+  border-radius: 1px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0
+}
+
+.highlight > .chroma::-webkit-scrollbar-thumb {
+  background-color: #dddee0;
+  border: 4px solid transparent;
+  background-clip: content-box;
+  border-radius: 10px
+}
+
+.highlight > .chroma::-webkit-scrollbar-thumb:hover {
+  background-color: #9d9e9f;
+}
+
+@include color-mode(dark) {
+  .highlight > .chroma::-webkit-scrollbar-thumb {
+    background-color: #ffffff17;
+  }
+
+  .highlight > .chroma::-webkit-scrollbar-thumb:hover {
+    background-color: #ffffff49;
   }
 }

--- a/assets/scss/components/_expressive-code.scss
+++ b/assets/scss/components/_expressive-code.scss
@@ -1,0 +1,572 @@
+.expressive-code {
+    font-family: var(--ec-uiFontFml);
+    font-size: var(--ec-uiFontSize);
+    line-height: var(--ec-uiLineHt);
+    text-size-adjust: none;
+    -webkit-text-size-adjust: none;
+    margin: 1.5rem 0;
+}
+
+.expressive-code *:not(path) {
+    all: revert;
+    box-sizing: border-box
+}
+
+.expressive-code pre {
+    display: flex;
+    margin: 0;
+    padding: 0;
+    border: var(--ec-brdWd) solid var(--ec-brdCol);
+    border-radius: calc(var(--ec-brdRad) + var(--ec-brdWd));
+    background: var(--ec-codeBg)
+}
+
+.expressive-code pre:focus-visible {
+    outline: 3px solid var(--ec-focusBrd);
+    outline-offset: -3px
+}
+
+.expressive-code pre > code {
+    all: unset;
+    display: block;
+    flex: 1 0 100%;
+    padding: var(--ec-codePadBlk) 0;
+    color: var(--ec-codeFg);
+    font-family: var(--ec-codeFontFml);
+    font-size: var(--ec-codeFontSize);
+    line-height: var(--ec-codeLineHt)
+}
+
+.expressive-code pre {
+    overflow-x: auto
+}
+
+.expressive-code pre::-webkit-scrollbar,.expressive-code pre::-webkit-scrollbar-track {
+    background-color: inherit;
+    border-radius: calc(var(--ec-brdRad) + var(--ec-brdWd));
+    border-top-left-radius: 0;
+    border-top-right-radius: 0
+}
+
+.expressive-code pre::-webkit-scrollbar-thumb {
+    background-color: var(--ec-sbThumbCol);
+    border: 4px solid transparent;
+    background-clip: content-box;
+    border-radius: 10px
+}
+
+.expressive-code pre::-webkit-scrollbar-thumb:hover {
+    background-color: var(--ec-sbThumbHoverCol)
+}
+
+.expressive-code .ec-line {
+    padding-inline:var(--ec-codePadInl);padding-inline-end: calc(2rem + var(--ec-codePadInl));
+    direction: ltr;
+    unicode-bidi: isolate
+}
+
+.expressive-code .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0
+}
+
+.expressive-code .ec-line.mark {
+    --tmLineBgCol: var(--ec-tm-markBg);
+    --tmLineBrdCol: var(--ec-tm-markBrdCol)
+}
+
+.expressive-code .ec-line.ins {
+    --tmLineBgCol: var(--ec-tm-insBg);
+    --tmLineBrdCol: var(--ec-tm-insBrdCol)
+}
+
+.expressive-code .ec-line.ins::before {
+    content: var(--ec-tm-insDiffIndContent);
+    color: var(--ec-tm-insDiffIndCol)
+}
+
+.expressive-code .ec-line.del {
+    --tmLineBgCol: var(--ec-tm-delBg);
+    --tmLineBrdCol: var(--ec-tm-delBrdCol)
+}
+
+.expressive-code .ec-line.del::before {
+    content: var(--ec-tm-delDiffIndContent);
+    color: var(--ec-tm-delDiffIndCol)
+}
+
+.expressive-code .ec-line.mark,.expressive-code .ec-line.ins,.expressive-code .ec-line.del {
+    position: relative;
+    background: var(--tmLineBgCol);
+    min-width: calc(100% - var(--ec-tm-lineMarkerAccentMarg));
+    margin-inline-start:var(--ec-tm-lineMarkerAccentMarg);border-inline-start: var(--ec-tm-lineMarkerAccentWd) solid var(--tmLineBrdCol);
+    padding-inline-start:calc(var(--ec-codePadInl) - var(--ec-tm-lineMarkerAccentMarg) - var(--ec-tm-lineMarkerAccentWd)) !important}
+
+.expressive-code .ec-line.mark::before,.expressive-code .ec-line.ins::before,.expressive-code .ec-line.del::before {
+    position:absolute;
+    left: var(--ec-tm-lineDiffIndMargLeft)
+}
+
+.expressive-code .ec-line mark {
+    --tmInlineBgCol: var(--ec-tm-markBg);
+    --tmInlineBrdCol: var(--ec-tm-markBrdCol)
+}
+
+.expressive-code .ec-line ins {
+    --tmInlineBgCol: var(--ec-tm-insBg);
+    --tmInlineBrdCol: var(--ec-tm-insBrdCol)
+}
+
+.expressive-code .ec-line del {
+    --tmInlineBgCol: var(--ec-tm-delBg);
+    --tmInlineBrdCol: var(--ec-tm-delBrdCol)
+}
+
+.expressive-code .ec-line mark,.expressive-code .ec-line ins,.expressive-code .ec-line del {
+    all: unset;
+    display: inline-block;
+    position: relative;
+    --tmBrdL: var(--ec-tm-inlMarkerBrdWd);
+    --tmBrdR: var(--ec-tm-inlMarkerBrdWd);
+    --tmRadL: var(--ec-tm-inlMarkerBrdRad);
+    --tmRadR: var(--ec-tm-inlMarkerBrdRad);
+    margin-inline:0.025rem;padding-inline:var(--ec-tm-inlMarkerPad);border-radius: var(--tmRadL) var(--tmRadR) var(--tmRadR) var(--tmRadL);
+    background: var(--tmInlineBgCol);
+    background-clip: padding-box
+}
+
+.expressive-code .ec-line mark.open-start,.expressive-code .ec-line ins.open-start,.expressive-code .ec-line del.open-start {
+    margin-inline-start:0;padding-inline-start:0;--tmBrdL: 0px;
+    --tmRadL: 0
+}
+
+.expressive-code .ec-line mark.open-end,.expressive-code .ec-line ins.open-end,.expressive-code .ec-line del.open-end {
+    margin-inline-end:0;padding-inline-end:0;--tmBrdR: 0px;
+    --tmRadR: 0
+}
+
+.expressive-code .ec-line mark::before,.expressive-code .ec-line ins::before,.expressive-code .ec-line del::before {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    display: inline-block;
+    inset: 0;
+    border-radius: var(--tmRadL) var(--tmRadR) var(--tmRadR) var(--tmRadL);
+    border: var(--ec-tm-inlMarkerBrdWd) solid var(--tmInlineBrdCol);
+    border-inline-width:var(--tmBrdL) var(--tmBrdR)}
+
+.expressive-code .frame {
+    all: unset;
+    position: relative;
+    display: block;
+    --header-border-radius: calc(var(--ec-brdRad) + var(--ec-brdWd));
+    --tab-border-radius: calc(var(--ec-frm-edTabBrdRad) + var(--ec-brdWd));
+    --button-spacing: 0.4rem;
+    --code-background: var(--ec-frm-edBg);
+    border-radius: var(--header-border-radius);
+    box-shadow: var(--ec-frm-frameBoxShdCssVal)
+}
+
+.expressive-code .frame .header {
+    display: none;
+    z-index: 1;
+    position: relative;
+    border-radius: var(--header-border-radius) var(--header-border-radius) 0 0
+}
+
+.expressive-code .frame.has-title pre,.expressive-code .frame.has-title code,.expressive-code .frame.is-terminal pre,.expressive-code .frame.is-terminal code {
+    border-top: none;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0
+}
+
+.expressive-code .frame .title:empty:before {
+    content: '\a0'
+}
+
+.expressive-code .frame.has-title:not(.is-terminal) {
+    --button-spacing: calc(1.9rem + 2 * (var(--ec-uiPadBlk) + var(--ec-frm-edActTabIndHt)))
+}
+
+.expressive-code .frame.has-title:not(.is-terminal) .title {
+    position: relative;
+    color: var(--ec-frm-edActTabFg);
+    background: var(--ec-frm-edActTabBg);
+    background-clip: padding-box;
+    margin-block-start:var(--ec-frm-edTabsMargBlkStart);padding: calc(var(--ec-uiPadBlk) + var(--ec-frm-edActTabIndHt)) var(--ec-uiPadInl);
+    border: var(--ec-brdWd) solid var(--ec-frm-edActTabBrdCol);
+    border-radius: var(--tab-border-radius) var(--tab-border-radius) 0 0;
+    border-bottom: none;
+    overflow: hidden
+}
+
+.expressive-code .frame.has-title:not(.is-terminal) .title::after {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    inset: 0;
+    border-top: var(--ec-frm-edActTabIndHt) solid var(--ec-frm-edActTabIndTopCol);
+    border-bottom: var(--ec-frm-edActTabIndHt) solid var(--ec-frm-edActTabIndBtmCol)
+}
+
+.expressive-code .frame.has-title:not(.is-terminal) .header {
+    display: flex;
+    background: linear-gradient(to top, var(--ec-frm-edTabBarBrdBtmCol) var(--ec-brdWd), transparent var(--ec-brdWd)),linear-gradient(var(--ec-frm-edTabBarBg), var(--ec-frm-edTabBarBg));
+    background-repeat: no-repeat;
+    padding-inline-start:var(--ec-frm-edTabsMargInlStart)}
+
+.expressive-code .frame.has-title:not(.is-terminal) .header::before {
+    content:'';
+    position: absolute;
+    pointer-events: none;
+    inset: 0;
+    border: var(--ec-brdWd) solid var(--ec-frm-edTabBarBrdCol);
+    border-radius: inherit;
+    border-bottom: none
+}
+
+.expressive-code .frame.is-terminal {
+    --button-spacing: calc(1.9rem + var(--ec-brdWd) + 2 * var(--ec-uiPadBlk));
+    --code-background: var(--ec-frm-trmBg)
+}
+
+.expressive-code .frame.is-terminal .header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-block:var(--ec-uiPadBlk);padding-block-end: calc(var(--ec-uiPadBlk) + var(--ec-brdWd));
+    position: relative;
+    font-weight: 500;
+    letter-spacing: 0.025ch;
+    color: var(--ec-frm-trmTtbFg);
+    background: var(--ec-frm-trmTtbBg);
+    border: var(--ec-brdWd) solid var(--ec-brdCol);
+    border-bottom: none
+}
+
+.expressive-code .frame.is-terminal .header::before {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    left: var(--ec-uiPadInl);
+    width: 2.1rem;
+    height: 0.56rem;
+    line-height: 0;
+    background-color: var(--ec-frm-trmTtbDotsFg);
+    opacity: var(--ec-frm-trmTtbDotsOpa);
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 16' preserveAspectRatio='xMidYMid meet'%3E%3Ccircle cx='8' cy='8' r='8'/%3E%3Ccircle cx='30' cy='8' r='8'/%3E%3Ccircle cx='52' cy='8' r='8'/%3E%3C/svg%3E");
+    -webkit-mask-repeat: no-repeat;
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 16' preserveAspectRatio='xMidYMid meet'%3E%3Ccircle cx='8' cy='8' r='8'/%3E%3Ccircle cx='30' cy='8' r='8'/%3E%3Ccircle cx='52' cy='8' r='8'/%3E%3C/svg%3E");
+    mask-repeat: no-repeat
+}
+
+.expressive-code .frame.is-terminal .header::after {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    inset: 0;
+    border-bottom: var(--ec-brdWd) solid var(--ec-frm-trmTtbBrdBtmCol)
+}
+
+.expressive-code .frame pre {
+    background: var(--code-background)
+}
+
+.expressive-code .copy {
+    display: flex;
+    gap: 0.25rem;
+    flex-direction: row;
+    position: absolute;
+    inset-block-start: calc(var(--ec-brdWd) + var(--button-spacing));
+    inset-inline-end: calc(var(--ec-brdWd) + var(--ec-uiPadInl) / 2);
+    direction: ltr;
+    unicode-bidi: isolate
+}
+
+.expressive-code .copy button {
+    position: relative;
+    align-self: flex-end;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: 0.2rem;
+    z-index: 1;
+    cursor: pointer;
+    transition-property: opacity, background, border-color;
+    transition-duration: 0.2s;
+    transition-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    width: 2.5rem;
+    height: 2.5rem;
+    background: var(--code-background);
+    opacity: 0.75
+}
+
+.expressive-code .copy button div {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--ec-frm-inlBtnBg);
+    opacity: var(--ec-frm-inlBtnBgIdleOpa);
+    transition-property: inherit;
+    transition-duration: inherit;
+    transition-timing-function: inherit
+}
+
+.expressive-code .copy button::before {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    inset: 0;
+    border-radius: inherit;
+    border: var(--ec-brdWd) solid var(--ec-frm-inlBtnBrd);
+    opacity: var(--ec-frm-inlBtnBrdOpa)
+}
+
+.expressive-code .copy button::after {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    inset: 0;
+    background-color: var(--ec-frm-inlBtnFg);
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.75'%3E%3Cpath d='M3 19a2 2 0 0 1-1-2V2a2 2 0 0 1 1-1h13a2 2 0 0 1 2 1'/%3E%3Crect x='6' y='5' width='16' height='18' rx='1.5' ry='1.5'/%3E%3C/svg%3E");
+    -webkit-mask-repeat: no-repeat;
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.75'%3E%3Cpath d='M3 19a2 2 0 0 1-1-2V2a2 2 0 0 1 1-1h13a2 2 0 0 1 2 1'/%3E%3Crect x='6' y='5' width='16' height='18' rx='1.5' ry='1.5'/%3E%3C/svg%3E");
+    mask-repeat: no-repeat;
+    margin: 0.475rem;
+    line-height: 0
+}
+
+
+// Check icon
+.expressive-code .copy button:focus::after,
+.expressive-code .copy button:active::after {
+  display: inline-block;
+  content: '';
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' viewBox='0 0 24 24' stroke-width='1.25' stroke='black' fill='none' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'%3E%3C/path%3E%3Cpath d='M5 12l5 5l10 -10'%3E%3C/path%3E%3C/svg%3E") no-repeat 50% 50%;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' viewBox='0 0 24 24' stroke-width='1.25' stroke='black' fill='none' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'%3E%3C/path%3E%3Cpath d='M5 12l5 5l10 -10'%3E%3C/path%3E%3C/svg%3E") no-repeat 50% 50%;
+  -webkit-mask-size: cover;
+  mask-size: cover;
+  margin: 0.2375rem;
+
+  // background-color: $gray-700;
+  // background-color: var(--sl-color-green-high);
+}
+
+.expressive-code .copy button:hover,.expressive-code .copy button:focus:focus-visible {
+    opacity: 1
+}
+
+.expressive-code .copy button:hover div,.expressive-code .copy button:focus:focus-visible div {
+    opacity: var(--ec-frm-inlBtnBgHoverOrFocusOpa)
+}
+
+.expressive-code .copy button:active {
+    opacity: 1
+}
+
+.expressive-code .copy button:active div {
+    opacity: var(--ec-frm-inlBtnBgActOpa)
+}
+
+.expressive-code .copy .feedback {
+    --tooltip-arrow-size: 0.35rem;
+    --tooltip-bg: var(--ec-frm-tooltipSuccessBg);
+    color: var(--ec-frm-tooltipSuccessFg);
+    pointer-events: none;
+    user-select: none;
+    -webkit-user-select: none;
+    position: relative;
+    align-self: center;
+    background-color: var(--tooltip-bg);
+    z-index: 99;
+    padding: 0.125rem 0.75rem;
+    border-radius: 0.2rem;
+    margin-inline-end:var(--tooltip-arrow-size);opacity: 0;
+    transition-property: opacity, transform;
+    transition-duration: 0.2s;
+    transition-timing-function: ease-in-out;
+    transform: translate3d(0, 0.25rem, 0)
+}
+
+.expressive-code .copy .feedback::after {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    top: calc(50% - var(--tooltip-arrow-size));
+    inset-inline-end: calc(-2 * (var(--tooltip-arrow-size) - 0.5px));
+    border: var(--tooltip-arrow-size) solid transparent;
+    border-inline-start-color:var(--tooltip-bg)}
+
+.expressive-code .copy .feedback.show {
+    opacity: 1;
+    transform: translate3d(0, 0, 0)
+}
+
+@media (hover: hover) {
+    .expressive-code {
+    }
+
+    .expressive-code .copy button {
+        opacity: 0;
+        width: 2rem;
+        height: 2rem
+    }
+
+    .expressive-code .frame:hover .copy button:not(:hover),.expressive-code .frame:focus-within :focus-visible ~ .copy button:not(:hover),.expressive-code .frame .copy .feedback.show ~ button:not(:hover) {
+        opacity: 0.75
+    }
+}
+
+:root {
+    --ec-brdRad: 0px;
+    --ec-brdWd: 1px;
+    --ec-brdCol: color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+    --ec-codeFontFml: var(--__sl-font-mono);
+    --ec-codeFontSize: var(--sl-text-code);
+    --ec-codeFontWg: 400;
+    --ec-codeLineHt: var(--sl-line-height);
+    --ec-codePadBlk: 0; // 0.75rem;
+    --ec-codePadInl: 1rem;
+    --ec-codeBg: #011627;
+    --ec-codeFg: #d6deeb;
+    --ec-codeSelBg: #1d3b53;
+    --ec-uiFontFml: var(--__sl-font);
+    --ec-uiFontSize: 0.9rem;
+    --ec-uiFontWg: 400;
+    --ec-uiLineHt: 1.65;
+    --ec-uiPadBlk: 0.25rem;
+    --ec-uiPadInl: 1rem;
+    --ec-uiSelBg: #234d708c;
+    --ec-uiSelFg: #ffffff;
+    --ec-focusBrd: #122d42;
+    --ec-sbThumbCol: #ffffff17;
+    --ec-sbThumbHoverCol: #ffffff49;
+    --ec-tm-lineMarkerAccentMarg: 0rem;
+    --ec-tm-lineMarkerAccentWd: 0.15rem;
+    --ec-tm-lineDiffIndMargLeft: 0.25rem;
+    --ec-tm-inlMarkerBrdWd: 1.5px;
+    --ec-tm-inlMarkerBrdRad: 0.2rem;
+    --ec-tm-inlMarkerPad: 0.15rem;
+    --ec-tm-insDiffIndContent: '+';
+    --ec-tm-delDiffIndContent: '-';
+    --ec-tm-markBg: #ffffff17;
+    --ec-tm-markBrdCol: #ffffff40;
+    --ec-tm-insBg: #1e571599;
+    --ec-tm-insBrdCol: #487f3bd0;
+    --ec-tm-insDiffIndCol: #79b169d0;
+    --ec-tm-delBg: #862d2799;
+    --ec-tm-delBrdCol: #b4554bd0;
+    --ec-tm-delDiffIndCol: #ed8779d0;
+    --ec-frm-shdCol: #011627;
+    --ec-frm-frameBoxShdCssVal: none;
+    --ec-frm-edActTabBg: var(--sl-color-gray-6);
+    --ec-frm-edActTabFg: var(--sl-color-text);
+    --ec-frm-edActTabBrdCol: transparent;
+    --ec-frm-edActTabIndHt: 1px;
+    --ec-frm-edActTabIndTopCol: var(--sl-color-accent-high);
+    --ec-frm-edActTabIndBtmCol: transparent;
+    --ec-frm-edTabsMargInlStart: 0;
+    --ec-frm-edTabsMargBlkStart: 0;
+    --ec-frm-edTabBrdRad: 0px;
+    --ec-frm-edTabBarBg: var(--sl-color-black);
+    --ec-frm-edTabBarBrdCol: color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+    --ec-frm-edTabBarBrdBtmCol: color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+    --ec-frm-edBg: var(--sl-color-gray-6);
+    --ec-frm-trmTtbDotsFg: color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+    --ec-frm-trmTtbDotsOpa: 0.75;
+    --ec-frm-trmTtbBg: var(--sl-color-black);
+    --ec-frm-trmTtbFg: var(--sl-color-text);
+    --ec-frm-trmTtbBrdBtmCol: color-mix(in srgb, var(--sl-color-gray-5), transparent 25%);
+    --ec-frm-trmBg: var(--sl-color-gray-6);
+    --ec-frm-inlBtnFg: var(--sl-color-text);
+    --ec-frm-inlBtnBg: var(--sl-color-text);
+    --ec-frm-inlBtnBgIdleOpa: 0;
+    --ec-frm-inlBtnBgHoverOrFocusOpa: 0.2;
+    --ec-frm-inlBtnBgActOpa: 0.3;
+    --ec-frm-inlBtnBrd: var(--sl-color-text);
+    --ec-frm-inlBtnBrdOpa: 0.4;
+    --ec-frm-tooltipSuccessBg: #158744;
+    --ec-frm-tooltipSuccessFg: white
+}
+
+.expressive-code .ec-line span[style^='--']:not([class]) {
+    color: var(--0, inherit);
+    font-style: var(--0fs, inherit);
+    font-weight: var(--0fw, inherit);
+    text-decoration: var(--0td, inherit)
+}
+
+@media (prefers-color-scheme: light) {
+    :root:not([data-bs-theme='dark']) {
+        --ec-codeBg:#fbfbfb;
+        --ec-codeFg: #403f53;
+        --ec-codeSelBg: #e0e0e0;
+        --ec-uiSelBg: #d3e8f8;
+        --ec-uiSelFg: #403f53;
+        --ec-focusBrd: #93a1a1;
+        --ec-sbThumbCol: #0000001a;
+        --ec-sbThumbHoverCol: #0000005c;
+        --ec-tm-markBg: #0000001a;
+        --ec-tm-markBrdCol: #00000055;
+        --ec-tm-insBg: #8ec77d99;
+        --ec-tm-insDiffIndCol: #336a28d0;
+        --ec-tm-delBg: #ff9c8e99;
+        --ec-tm-delDiffIndCol: #9d4138d0;
+        --ec-frm-shdCol: #d9d9d9;
+        --ec-frm-edActTabBg: var(--sl-color-gray-7);
+        // --ec-frm-edActTabIndTopCol: var(--sl-color-accent);
+        --ec-frm-edActTabIndTopCol: #5d2f86;
+        --ec-frm-edTabBarBg: var(--sl-color-gray-6);
+        --ec-frm-edBg: var(--sl-color-gray-7);
+        --ec-frm-trmTtbBg: var(--sl-color-gray-6);
+        --ec-frm-trmBg: var(--sl-color-gray-7);
+        --ec-frm-tooltipSuccessBg: #078662
+    }
+
+    :root:not([data-bs-theme='dark']) .expressive-code .ec-line span[style^='--']:not([class]) {
+        color: var(--1, inherit);
+        font-style: var(--1fs, inherit);
+        font-weight: var(--1fw, inherit);
+        text-decoration: var(--1td, inherit)
+    }
+}
+
+:root[data-bs-theme='light'] .expressive-code,.expressive-code[data-bs-theme='light'] {
+    --ec-codeBg: #fbfbfb;
+    --ec-codeFg: #403f53;
+    --ec-codeSelBg: #e0e0e0;
+    --ec-uiSelBg: #d3e8f8;
+    --ec-uiSelFg: #403f53;
+    --ec-focusBrd: #93a1a1;
+    --ec-sbThumbCol: #0000001a;
+    --ec-sbThumbHoverCol: #0000005c;
+    --ec-tm-markBg: #0000001a;
+    --ec-tm-markBrdCol: #00000055;
+    --ec-tm-insBg: #8ec77d99;
+    --ec-tm-insDiffIndCol: #336a28d0;
+    --ec-tm-delBg: #ff9c8e99;
+    --ec-tm-delDiffIndCol: #9d4138d0;
+    --ec-frm-shdCol: #d9d9d9;
+    --ec-frm-edActTabBg: var(--sl-color-gray-7);
+    // --ec-frm-edActTabIndTopCol: var(--sl-color-accent);
+    --ec-frm-edActTabIndTopCol: #5d2f86;
+    --ec-frm-edTabBarBg: var(--sl-color-gray-6);
+    --ec-frm-edBg: var(--sl-color-gray-7);
+    --ec-frm-trmTtbBg: var(--sl-color-gray-6);
+    --ec-frm-trmBg: var(--sl-color-gray-7);
+    --ec-frm-tooltipSuccessBg: #078662
+}
+
+:root[data-bs-theme='light'] .expressive-code .ec-line span[style^='--']:not([class]),.expressive-code[data-bs-theme='light'] .ec-line span[style^='--']:not([class]) {
+    color: var(--1, inherit);
+    font-style: var(--1fs, inherit);
+    font-weight: var(--1fw, inherit);
+    text-decoration: var(--1td, inherit)
+}

--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -85,3 +85,9 @@ img[data-sizes="auto"] {
   margin-bottom: 0.125rem;
   margin-right: 0.5rem;
 }
+
+figcaption {
+  font-size: 1rem;
+  margin-top: 0.5rem;
+  font-style: italic;
+}

--- a/assets/scss/components/_modals.scss
+++ b/assets/scss/components/_modals.scss
@@ -59,8 +59,14 @@
   outline: 0 none;
 } 
 
+.search-result .content {
+  margin-top: 0.5rem;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
 .search-result .card .content {
-  P {
+  p {
     margin-bottom: 0;
   }
 
@@ -102,10 +108,4 @@
 .search-result .submitted {
   font-size: $font-size-sm;
   margin-top: 0.5rem;
-}
-
-.search-result .content {
-  margin-top: 0.5rem;
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
 }

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,0 +1,5 @@
+{{ $title := .Attributes.title }}
+
+{{ $result := transform.HighlightCodeBlock . }}
+{{ with $title }}{{ . }}{{ end }}
+{{ $result.Wrapped }}

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,5 +1,25 @@
-{{ $title := .Attributes.title }}
+{{- $terminalLanguages := slice "bash" "sh" "shell" "powershell" }}
+{{- $terminalClass := "" }}
+{{- $frame := .Attributes.frame }}
+{{- if and (ne $frame "none") (in $terminalLanguages .Type) }}
+  {{- $terminalClass = " is-terminal" }}
+{{- end }}
 
-{{ $result := transform.HighlightCodeBlock . }}
-{{ with $title }}{{ . }}{{ end }}
-{{ $result.Wrapped }}
+{{- $title := .Attributes.title }}
+{{- $titleClass := "" }}
+{{ with $title}}
+  {{- $titleClass = " has-title" }}
+{{- end }}
+
+{{- $result := transform.HighlightCodeBlock . }}
+
+<div class="expressive-code">
+  <figure class="frame{{ $terminalClass }}{{ $titleClass }} not-content">
+  <figcaption class="header">
+    <span class="title">
+      {{- with $title -}}{{ . }}{{- end -}}
+    </span>
+  </figcaption>
+  {{ $result.Wrapped }}
+  </figure>
+</div>


### PR DESCRIPTION
## Summary

Brief explanation of the proposed changes.

Add default `figcaption` styling — see e.g. https://images.gethyas.com/docs/shortcodes/figure/#page-resource

## Basic example

Include a basic example, screenshots, or links.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

https://github.com/gethyas/doks/issues/1139

## Checks

- [ ] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
