### PR TITLE
Adds figcaption styling

### DIFF
--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -85,3 +85,9 @@ img[data-sizes="auto"] {
   margin-bottom: 0.125rem;
   margin-right: 0.5rem;
 }
+
+figcaption {
+  font-size: 1rem;
+  margin-top: 0.5rem;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary

Brief explanation of the proposed changes.

Add default `figcaption` styling — see e.g. https://images.gethyas.com/docs/shortcodes/figure/#page-resource

## Basic example

Include a basic example, screenshots, or links.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

https://github.com/gethyas/doks/issues/1139

## Checks

- [ ] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
