### PR TITLE
Update single.html for multi language support

### DIFF
--- a/layouts/legal/single.html
+++ b/layouts/legal/single.html
@@ -4,7 +4,7 @@
   <div class="col-md-12 col-lg-10">
     <div class="blog-header">
       <h1>{{ .Title }}</h1>
-      <p>Last updated on {{ .Lastmod.Format "January 2, 2006" }}</p>
+      <p>{{ i18n "last_updated"}}&nbsp;{{- time.Format (default ":date_long" .Site.Params.dateFormat) .Lastmod -}}</p>
     </div>
   </div>
   {{- $images := .Resources.ByType "image" -}}


### PR DESCRIPTION
This layout file didn't use any formatting for multilanguage sites (the i18n en/nl toml did however already support it). So this is an easy fix that looks a bit nicer on your dutch legal pages.

## Summary

same approach for multi language date as in the blog-meta partial

## Motivation

Our dutch page said" 'last updated' instead of 'laatst geupdate'

## Checks

- [ ] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
