### PR TITLE
Adds no wrap for reading time

### DIFF
--- a/layouts/partials/main/blog-meta.html
+++ b/layouts/partials/main/blog-meta.html
@@ -25,7 +25,7 @@
       {{- end }}
     {{- end -}}
     {{- /* NOTE: classes 'stretched-link position-relative' are necessary to properly display the title attribute on hover */ -}}
-    <span class="stretched-link position-relative reading-time" title="{{ i18n "reading_time" }}">{{/* trim subsequent whitespace */ -}}
+    <span class="stretched-link position-relative reading-time text-nowrap" title="{{ i18n "reading_time" }}">{{/* trim subsequent whitespace */ -}}
       <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-clock" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
         <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
         <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"></path>


### PR DESCRIPTION
Reading time used to wrap to a new row, thereby distancing the reading time icon from the duration

## Summary

I used the default Bootstrap 'text-nowrap' class to make sure that the reading time doesn't wrap to the next line without the icon. I checked this with all window sizes and it seems to work well in Chrome and Safari. 

## Basic example

new:
<img width="507" alt="Scherm­afbeelding 2024-01-14 om 21 41 02" src="https://github.com/gethyas/doks-core/assets/30504008/4f50ef01-7e43-47aa-932e-03ef78d5aedf">

old:
<img width="548" alt="Scherm­afbeelding 2024-01-14 om 21 40 43" src="https://github.com/gethyas/doks-core/assets/30504008/f62b86cb-7c94-43f1-a530-f5242f42b275">


## Motivation

The old method looked a bit ugly on certain screen sizes (especially mobile and with multiple authors). I also changed the margin-left from reading-time to 1rem, because I think the default is a bit too much. That's why my screenshot might look a little bit different. Nevertheless, I believe that the icon should always be on the same line as the duration. 

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
