### PR TITLE
fix: docs repo subpath ignored

### DIFF
--- a/layouts/partials/main/edit-page.html
+++ b/layouts/partials/main/edit-page.html
@@ -12,7 +12,7 @@
   {{ $parts = $parts | append "browse" site.Params.doks.docsRepoBranch }}
 {{ end }}
 
-{{ if isset .Site.Params "docsreposubpath" }}
+{{ if isset .Site.Params.doks "docsreposubpath" }}
   {{ if not (eq site.Params.doks.docsRepoSubPath "") }}
     {{ $parts = $parts | append site.Params.doks.docsRepoSubPath }}
   {{ end }}


### PR DESCRIPTION
## Summary

This fixes an issue where the docsRepoSubPath option is ignored. This was caused due to a refactoring moving the docsRepoSubPath option under the doks key.

## Basic example

N/A

## Motivation

This option does nothing currently as the two checks are inconsistent.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
