### PR TITLE
feat: allow custom kroki host

### DIFF
--- a/.changeset/five-grapes-smash.md
+++ b/.changeset/five-grapes-smash.md
@@ -1,0 +1,5 @@
+---
+"@hyas/doks-core": patch
+---
+
+Allow custom kroki host

--- a/layouts/_default/_markup/render-codeblock-kroki.html
+++ b/layouts/_default/_markup/render-codeblock-kroki.html
@@ -53,7 +53,7 @@ References:
 {{- $position := .Position }}
 
 {{- /* Initialize. */}}
-{{- $apiEndpoint := "https://kroki.io/" }}
+{{- $apiEndpoint := or site.Params.doks.krokiURL "https://kroki.io/" }}
 {{- $diagramType := $attrs.type | lower }}
 
 {{- /* Validate diagram type. */}}


### PR DESCRIPTION
## Summary

Allow users to provide a custom Kroki URL instead of hard-coding
https://kroki.io.

## Basic example

In `params.toml`, users of this theme can set a custom Kroki URL, such
as a local instance:

```toml
[doks]
    krokiURL = "http://localhost:8000"
```

I tried my best to keep proper backwards compatibility should users not
provide this configuration key *at all*—see the diff. Should this not be
acceptable, please let me know.

## Motivation

At times, the upstream kroki.io service may run into resource exhaustion.
This can be due to a high volume of requests or a temporary outage.
During an automated build, this isn't so bad—caches should exist and
therefore not hit Kroki as often.

However, especially during the writing phase of
documentation, where fast iteration is often needed, it is not helpful
when the upstream service runs into said resource exhaustion and responds
with an unhelpful "Bad Request" error.

This issue is known and understood by the Kroki team; the fix is to run
your own instance.[^1]

---

I will shortly raise a PR to gethyas/doks to reflect this change in the
configuration files.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`

*Note: npm complains about not having a `test` script, therefore I could
not run it, hence unchecked.*

[^1]: https://kroki.zulipchat.com/#narrow/stream/232085-users/topic/kroki.2Eio.20returns.20400.20on.20Mermaid.20diagrams
