### PR TITLE
feat: generate JS script hashes for CSP

### DIFF
--- a/layouts/_partials/footer/esbuild-hash-template.html
+++ b/layouts/_partials/footer/esbuild-hash-template.html
@@ -1,0 +1,97 @@
+{{- /* ESBUILD.HTML - Build javascript modules with esbuild
+  * Simple Usage: {{ partial "esbuild" "js/file.js" }}
+  * Simple Usage: {{ partial "esbuild" (dict "src" "js/file.js" "load" "defer/async" "babel" true ) }}
+  * Parameters:
+  * src - javascript file to build, relative to assets folder. Must include file extension can be .js or .ts
+  * load - can set to "defer" or "async" defaults to null.
+  * babel - set to true to transpile your js using babel. Note: all js is lowered to es6 by default.
+  * for babel you must have the required babel dependencies installed , and configured
+  * see hugo babel doc https://gohugo.io/hugo-pipes/babel
+  * use the babel option if esbuild can't handle lowering your es6+ code, or you wish to go lower than es6
+  * for unsupported es6+ syntax see
+  * https://esbuild.github.io/content-types/#javascript
+  *
+  * example for checking hugo env from js file
+  *
+  * import * as params from '@params';
+  *
+  * if (params.env === 'development') {
+  *   console.log('hugo deveolopment environment')
+  * } else {
+  *   console.log('hugo production environment')
+  * }
+  *
+  * ----------------------------------------------------------------*/ -}}
+{{- /* get source from . or .src and fetch resource */ -}}
+{{- $src := . -}}
+{{- if not $src -}}
+  {{- errorf `You must provide a source as the partial context, or (dict .src "path")` -}}
+{{- end -}}
+
+{{- /* set .load only if valid option provided in dict */ -}}
+{{- $load := "" -}}
+
+{{- /* set .babel only if provided in dict */ -}}
+{{- $babel := false -}}
+
+{{- /* check for dict */ -}}
+{{- if reflect.IsMap . -}}
+  {{- with .src -}}
+    {{- $src = . -}}
+  {{- else -}}
+    {{- errorf "as you are providing params as a dict, you must provide the source file as .src" -}}
+  {{- end -}}
+  {{- with .load -}}
+    {{- $loadOpts := slice "async" "defer" -}}
+    {{- if not (in $loadOpts . ) -}}
+      {{- errorf "Invalid .load %q for file /assets/%s - valid options are %s." . $src (delimit $loadOpts ", " " and " ) -}}
+    {{- end -}}
+    {{- $load = . }}
+  {{- end -}}
+  {{- with .babel -}}
+    {{- if eq . true -}}
+      {{- $babel = true -}}
+    {{- else -}}
+      {{- errorf "Invalid .babel option of %q. The only valid option is true" . -}}
+    {{- end -}}
+  {{- end -}}
+{{ end }}
+
+{{- /* get the resource from .src path */ -}}
+{{- $resource := resources.Get $src -}}
+
+{{- /* if resources.Get fails */ -}}
+{{- if not $resource }}
+  {{- errorf "No js resource found at /assets/%s" $src -}}
+{{- end -}}
+
+{{- /* pass hugo env to the js file as a param */ -}}
+{{- $paramsDefault := (dict "env" hugo.Environment) -}}
+{{- $params := "" -}}
+{{- with .params -}}
+  {{- $params = merge $paramsDefault . -}}
+{{- else -}}
+  {{- $params = $paramsDefault -}}
+{{- end -}}
+{{- $resource = $resource | resources.ExecuteAsTemplate $src . -}}
+
+{{- /* standard production configuration for es build */ -}}
+{{- $jsConfig := (dict "target" "es2015" "minify" "true" "params" $params) }}
+
+{{- /* is .babelEs6 is set to true - use babel to lower to es6 */ -}}
+{{- $js := $resource -}}
+{{- if $babel -}}
+  {{- $babelConfig := (dict "noComments" true "minified" true "config" "config/babel.module.config.js") -}}
+  {{- $js = $js | js.Build $jsConfig | babel $babelConfig | fingerprint -}}
+{{- else if eq (hugo.Environment) "development" -}}
+  {{- $jsConfig = (dict "sourceMap" "inline" "target" "es2015" "params" $params) -}}
+  {{- $js = $js | js.Build $jsConfig | fingerprint -}}
+{{- else -}}
+  {{- $js = $js | js.Build $jsConfig | fingerprint -}}
+{{- end -}}
+{{- return (dict
+  "src" $src
+  "js" $js
+  "load" $load
+  "hash" $js.Data.Integrity
+) -}}

--- a/layouts/_partials/footer/esbuild-hash.html
+++ b/layouts/_partials/footer/esbuild-hash.html
@@ -1,0 +1,98 @@
+{{- /* ESBUILD-HASH.HTML - Build javascript modules with esbuild
+  * Simple Usage: {{ partial "esbuild" "js/file.js" }}
+  * Simple Usage: {{ partial "esbuild" (dict "src" "js/file.js" "load" "defer/async" "babel" true ) }}
+  * Parameters:
+  * src - javascript file to build, relative to assets folder. Must include file extension can be .js or .ts
+  * load - can set to "defer" or "async" defaults to null.
+  * babel - set to true to transpile your js using babel. Note: all js is lowered to es6 by default.
+  * for babel you must have the required babel dependencies installed , and configured
+  * see hugo babel doc https://gohugo.io/hugo-pipes/babel
+  * use the babel option if esbuild can't handle lowering your es6+ code, or you wish to go lower than es6
+  * for unsupported es6+ syntax see
+  * https://esbuild.github.io/content-types/#javascript
+  *
+  * example for checking hugo env from js file
+  *
+  * import * as params from '@params';
+  *
+  * if (params.env === 'development') {
+  *   console.log('hugo deveolopment environment')
+  * } else {
+  *   console.log('hugo production environment')
+  * }
+  *
+  * ----------------------------------------------------------------*/ -}}
+{{- /* get source from . or .src and fetch resource */ -}}
+{{- $src := . -}}
+{{- if not $src -}}
+  {{- errorf `You must provide a source as the partial context, or (dict .src "path")` -}}
+{{- end -}}
+
+{{- /* set .load only if valid option provided in dict */ -}}
+{{- $load := "" -}}
+
+{{- /* set .babel only if provided in dict */ -}}
+{{- $babel := false -}}
+
+{{- /* check for dict */ -}}
+{{- if reflect.IsMap . -}}
+  {{- with .src -}}
+    {{- $src = . -}}
+  {{- else -}}
+    {{- errorf "as you are providing params as a dict, you must provide the source file as .src" -}}
+  {{- end -}}
+  {{- with .load -}}
+    {{- $loadOpts := slice "async" "defer" -}}
+    {{- if not (in $loadOpts . ) -}}
+      {{- errorf "Invalid .load %q for file /assets/%s - valid options are %s." . $src (delimit $loadOpts ", " " and " ) -}}
+    {{- end -}}
+    {{- $load = . }}
+  {{- end -}}
+  {{- with .babel -}}
+    {{- if eq . true -}}
+      {{- $babel = true -}}
+    {{- else -}}
+      {{- errorf "Invalid .babel option of %q. The only valid option is true" . -}}
+    {{- end -}}
+  {{- end -}}
+{{ end }}
+
+{{- /* get the resource from .src path */ -}}
+{{- $resource := resources.Get $src -}}
+
+{{- /* if resources.Get fails */ -}}
+{{- if not $resource }}
+  {{- errorf "No js resource found at /assets/%s" $src -}}
+{{- end -}}
+
+{{- /* pass hugo env to the js file as a param */ -}}
+{{- /* $params := (dict "env" hugo.Environment) */ -}}
+
+{{- $paramsDefault := (dict "env" hugo.Environment) -}}
+{{- $params := "" -}}
+{{- with .params -}}
+  {{- $params = merge $paramsDefault . -}}
+{{- else -}}
+  {{- $params = $paramsDefault -}}
+{{- end -}}
+
+{{- /* standard production configuration for es build */ -}}
+{{- $jsConfig := (dict "target" "es2015" "minify" "true" "params" $params) }}
+{{- $js := $resource -}}
+
+{{- /* is .babelEs6 is set to true - use babel to lower to es6 */ -}}
+{{- if $babel -}}
+  {{- $babelConfig := (dict "noComments" true "minified" true "config" "config/babel.module.config.js") -}}
+  {{- $js = $js | js.Build $jsConfig | babel $babelConfig | fingerprint -}}
+{{- else if eq (hugo.Environment) "development" -}}
+  {{- $jsConfig = (dict "sourceMap" "inline" "target" "es2015" "params" $params) -}}
+  {{- $js = $js | js.Build $jsConfig | fingerprint -}}
+{{- else -}}
+  {{- $js = $js | js.Build $jsConfig | fingerprint -}}
+{{- end -}}
+{{- return (dict
+  "src" $src
+  "js" $js
+  "load" $load
+  "hash" $js.Data.Integrity
+) -}}

--- a/layouts/_partials/footer/esbuild-template.html
+++ b/layouts/_partials/footer/esbuild-template.html
@@ -1,96 +1,10 @@
-{{- /* ESBUILD.HTML - Build javascript modules with esbuild
-  * Simple Usage: {{ partial "esbuild" "js/file.js" }}
-  * Simple Usage: {{ partial "esbuild" (dict "src" "js/file.js" "load" "defer/async" "babel" true ) }}
-  * Parameters:
-  * src - javascript file to build, relative to assets folder. Must include file extension can be .js or .ts
-  * load - can set to "defer" or "async" defaults to null.
-  * babel - set to true to transpile your js using babel. Note: all js is lowered to es6 by default.
-  * for babel you must have the required babel dependencies installed , and configured
-  * see hugo babel doc https://gohugo.io/hugo-pipes/babel
-  * use the babel option if esbuild can't handle lowering your es6+ code, or you wish to go lower than es6
-  * for unsupported es6+ syntax see
-  * https://esbuild.github.io/content-types/#javascript
-  *
-  * example for checking hugo env from js file
-  *
-  * import * as params from '@params';
-  *
-  * if (params.env === 'development') {
-  *   console.log('hugo deveolopment environment')
-  * } else {
-  *   console.log('hugo production environment')
-  * }
-  *
-  * ----------------------------------------------------------------*/ -}}
-{{- /* get source from . or .src and fetch resource */ -}}
-{{- $src := . -}}
-{{- if not $src -}}
-  {{- errorf `You must provide a source as the partial context, or (dict .src "path")` -}}
-{{- end -}}
-
-{{- /* set .load only if valid option provided in dict */ -}}
-{{- $load := "" -}}
-
-{{- /* set .babel only if provided in dict */ -}}
-{{- $babel := false -}}
-
-{{- /* check for dict */ -}}
-{{- if reflect.IsMap . -}}
-  {{- with .src -}}
-    {{- $src = . -}}
-  {{- else -}}
-    {{- errorf "as you are providing params as a dict, you must provide the source file as .src" -}}
-  {{- end -}}
-  {{- with .load -}}
-    {{- $loadOpts := slice "async" "defer" -}}
-    {{- if not (in $loadOpts . ) -}}
-      {{- errorf "Invalid .load %q for file /assets/%s - valid options are %s." . $src (delimit $loadOpts ", " " and " ) -}}
-    {{- end -}}
-    {{- $load = . }}
-  {{- end -}}
-  {{- with .babel -}}
-    {{- if eq . true -}}
-      {{- $babel = true -}}
-    {{- else -}}
-      {{- errorf "Invalid .babel option of %q. The only valid option is true" . -}}
-    {{- end -}}
-  {{- end -}}
-{{ end }}
-
-{{- /* get the resource from .src path */ -}}
-{{- $resource := resources.Get $src -}}
-
-{{- /* if resources.Get fails */ -}}
-{{- if not $resource }}
-  {{- errorf "No js resource found at /assets/%s" $src -}}
-{{- end -}}
-
-{{- /* pass hugo env to the js file as a param */ -}}
-{{- $paramsDefault := (dict "env" hugo.Environment) -}}
-{{- $params := "" -}}
-{{- with .params -}}
-  {{- $params = merge $paramsDefault . -}}
-{{- else -}}
-  {{- $params = $paramsDefault -}}
-{{- end -}}
-{{- $resource = $resource | resources.ExecuteAsTemplate $src . -}}
-
-{{- /* standard production configuration for es build */ -}}
-{{- $jsConfig := (dict "target" "es2015" "minify" "true" "params" $params) }}
-
-{{- /* is .babelEs6 is set to true - use babel to lower to es6 */ -}}
-{{- $js := $resource -}}
-{{- if $babel -}}
-  {{- $babelConfig := (dict "noComments" true "minified" true "config" "config/babel.module.config.js") -}}
-  {{- $js = $js | js.Build $jsConfig | babel $babelConfig | fingerprint -}}
-{{- else if eq (hugo.Environment) "development" -}}
-  {{- $jsConfig = (dict "sourceMap" "inline" "target" "es2015" "params" $params) -}}
-  {{- $js = $js | js.Build $jsConfig | fingerprint -}}
-{{- else -}}
-  {{- $js = $js | js.Build $jsConfig | fingerprint -}}
-{{- end -}}
-
-<script {{ with $load }}{{ . | safeHTMLAttr }}{{ end }}
-  src="{{- $js.RelPermalink -}}"
-  integrity="{{- $js.Data.Integrity -}}">
-</script>
+{{- /* Call out to ESBILD-HASH-TEMPLATTE.HTML to generate JS and calculate hash
+   * We do it this way so the hash can be available for adding to the
+   * Content-Security-Policy headers
+*/ -}}
+{{- $scriptHash := partial "footer/esbuild-hash-template.html" . }}
+{{- with $scriptHash }}
+<script {{ with $scriptHash.load }}{{ . | safeHTMLAttr }}{{ end }}
+src="{{- $scriptHash.js.RelPermalink -}}"
+integrity="{{- $scriptHash.js.Data.Integrity -}}"></script>
+{{ end -}}

--- a/layouts/_partials/footer/esbuild.html
+++ b/layouts/_partials/footer/esbuild.html
@@ -1,97 +1,10 @@
-{{- /* ESBUILD.HTML - Build javascript modules with esbuild
-  * Simple Usage: {{ partial "esbuild" "js/file.js" }}
-  * Simple Usage: {{ partial "esbuild" (dict "src" "js/file.js" "load" "defer/async" "babel" true ) }}
-  * Parameters:
-  * src - javascript file to build, relative to assets folder. Must include file extension can be .js or .ts
-  * load - can set to "defer" or "async" defaults to null.
-  * babel - set to true to transpile your js using babel. Note: all js is lowered to es6 by default.
-  * for babel you must have the required babel dependencies installed , and configured
-  * see hugo babel doc https://gohugo.io/hugo-pipes/babel
-  * use the babel option if esbuild can't handle lowering your es6+ code, or you wish to go lower than es6
-  * for unsupported es6+ syntax see
-  * https://esbuild.github.io/content-types/#javascript
-  *
-  * example for checking hugo env from js file
-  *
-  * import * as params from '@params';
-  *
-  * if (params.env === 'development') {
-  *   console.log('hugo deveolopment environment')
-  * } else {
-  *   console.log('hugo production environment')
-  * }
-  *
-  * ----------------------------------------------------------------*/ -}}
-{{- /* get source from . or .src and fetch resource */ -}}
-{{- $src := . -}}
-{{- if not $src -}}
-  {{- errorf `You must provide a source as the partial context, or (dict .src "path")` -}}
-{{- end -}}
-
-{{- /* set .load only if valid option provided in dict */ -}}
-{{- $load := "" -}}
-
-{{- /* set .babel only if provided in dict */ -}}
-{{- $babel := false -}}
-
-{{- /* check for dict */ -}}
-{{- if reflect.IsMap . -}}
-  {{- with .src -}}
-    {{- $src = . -}}
-  {{- else -}}
-    {{- errorf "as you are providing params as a dict, you must provide the source file as .src" -}}
-  {{- end -}}
-  {{- with .load -}}
-    {{- $loadOpts := slice "async" "defer" -}}
-    {{- if not (in $loadOpts . ) -}}
-      {{- errorf "Invalid .load %q for file /assets/%s - valid options are %s." . $src (delimit $loadOpts ", " " and " ) -}}
-    {{- end -}}
-    {{- $load = . }}
-  {{- end -}}
-  {{- with .babel -}}
-    {{- if eq . true -}}
-      {{- $babel = true -}}
-    {{- else -}}
-      {{- errorf "Invalid .babel option of %q. The only valid option is true" . -}}
-    {{- end -}}
-  {{- end -}}
-{{ end }}
-
-{{- /* get the resource from .src path */ -}}
-{{- $resource := resources.Get $src -}}
-
-{{- /* if resources.Get fails */ -}}
-{{- if not $resource }}
-  {{- errorf "No js resource found at /assets/%s" $src -}}
-{{- end -}}
-
-{{- /* pass hugo env to the js file as a param */ -}}
-{{- /* $params := (dict "env" hugo.Environment) */ -}}
-
-{{- $paramsDefault := (dict "env" hugo.Environment) -}}
-{{- $params := "" -}}
-{{- with .params -}}
-  {{- $params = merge $paramsDefault . -}}
-{{- else -}}
-  {{- $params = $paramsDefault -}}
-{{- end -}}
-
-{{- /* standard production configuration for es build */ -}}
-{{- $jsConfig := (dict "target" "es2015" "minify" "true" "params" $params) }}
-{{- $js := $resource -}}
-
-{{- /* is .babelEs6 is set to true - use babel to lower to es6 */ -}}
-{{- if $babel -}}
-  {{- $babelConfig := (dict "noComments" true "minified" true "config" "config/babel.module.config.js") -}}
-  {{- $js = $js | js.Build $jsConfig | babel $babelConfig | fingerprint -}}
-{{- else if eq (hugo.Environment) "development" -}}
-  {{- $jsConfig = (dict "sourceMap" "inline" "target" "es2015" "params" $params) -}}
-  {{- $js = $js | js.Build $jsConfig | fingerprint -}}
-{{- else -}}
-  {{- $js = $js | js.Build $jsConfig | fingerprint -}}
-{{- end -}}
-
-<script {{ with $load }}{{ . | safeHTMLAttr }}{{ end }}
-  src="{{- $js.RelPermalink -}}"
-  integrity="{{- $js.Data.Integrity -}}">
-</script>
+{{- /* Call out to ESBILD-HASH.HTML to generate JS and calculate hash
+   * We do it this way so the hash can be available for adding to the
+   * Content-Security-Policy headers
+*/ -}}
+{{- $scriptHash := partial "footer/esbuild-hash.html" . }}
+{{- with $scriptHash }}
+<script {{ with $scriptHash.load }}{{ . | safeHTMLAttr }}{{ end }}
+src="{{- $scriptHash.js.RelPermalink -}}"
+integrity="{{- $scriptHash.js.Data.Integrity -}}"></script>
+{{ end -}}

--- a/layouts/_partials/head/header-custom-values/var-scriptHashes.html
+++ b/layouts/_partials/head/header-custom-values/var-scriptHashes.html
@@ -1,0 +1,41 @@
+{{- $scriptHashes := slice }}
+{{- $footerScriptHash := partial "footer/esbuild-hash" (dict "src" "js/app.js" "targetPath" "main.js" "load" "async" "transpile" false) -}}
+{{- $bootstrapScriptHash := partial "footer/esbuild-hash" (dict "src" "js/bootstrap.js" "load" "async" "transpile" false) -}}
+{{- $flexTemplateScriptHash := "" }}
+{{- $flexScriptHash := "" }}
+{{- $colorMode := "" }}
+{{- $alertDismissable := "" -}}
+
+{{- partial "main/showFlexSearch" . -}}
+{{- $showFlexSearch := .Scratch.Get "showFlexSearch" -}}
+{{- $searchLimit := site.Params.doks.searchLimit -}}
+{{- if $showFlexSearch -}}
+  {{- /* use lang-specific FlexSearch JS config file for multilingual site */ -}}
+  {{- $flexsearchLangConfigPath := "" -}}
+  {{- if site.LanguagePrefix -}}
+    {{- $flexsearchLangConfigPath = printf "js/flexsearch.%s.js" site.Language.Lang -}}
+    {{- /*  NOTE: we have to assign the pipe below to avoid outputting its return value ($flexsearchLangConfigPath) */ -}}
+    {{- $unusedVar := resources.Get "js/flexsearch.js" | resources.Copy $flexsearchLangConfigPath -}}
+  {{- else -}}
+    {{- $flexsearchLangConfigPath = "js/flexsearch.js" -}}
+  {{- end -}}
+  {{- $flexTemplateScriptHash = partial "footer/esbuild-hash-template" (dict "src" $flexsearchLangConfigPath "load" "async" "transpile" false "isMultilingual" hugo.IsMultilingual "searchLimit" $searchLimit) -}}
+  {{- $flexScriptHash = partial "footer/esbuild-hash" (dict "src" "js/search-modal.js" "load" "async" "transpile" false) -}}
+{{- end -}}
+
+{{- if eq site.Params.doks.colorMode "auto" }}
+  {{- $colorMode = partial "footer/esbuild-hash" (dict "src" "js/color-mode.js" "transpile" false) }}
+{{- end }}
+{{- if and (site.Params.doks.alert) (site.Params.doks.alertDismissable) }}
+  {{- $alertDismissable = partial "footer/esbuild-hash" (dict "src" "js/dismissable-alert.js" "transpile" false) }}
+{{- end -}}
+
+{{- $hashDicts := slice $footerScriptHash $bootstrapScriptHash $flexTemplateScriptHash $flexScriptHash $colorMode $alertDismissable -}}
+{{- range $hashDicts -}}
+  {{- with . }}
+    {{- with .hash }}
+      {{- $scriptHashes = $scriptHashes | append . }}
+    {{- end }}
+  {{- end -}}
+{{- end -}}
+{{- return $scriptHashes -}}


### PR DESCRIPTION
## Summary

Generate JS script hashes for CSP.
Avoids the need to hard code the hashes when using a CSP.
Depends on https://github.com/thuliteio/core/pull/27

## Basic example

See https://github.com/thuliteio/core/pull/27

## Motivation

Improve website security.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant) (not relevant)
- [x] Supports both light and dark mode (if relevant) (not relevant)
- [ ] Passes `npm run test` (if relevant)
