### PR TITLE
Fix contributors slice length calculation

### DIFF
--- a/.changeset/polite-drinks-begin.md
+++ b/.changeset/polite-drinks-begin.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+Fix contributors slice length calculation

--- a/layouts/_partials/main/blog-meta.html
+++ b/layouts/_partials/main/blog-meta.html
@@ -1,4 +1,5 @@
-{{ $last := sub (len (.Params.contributors | slice)) 1 -}}
+{{- $contributors := .Params.contributors | default (slice) -}}
+{{- $last := sub (len $contributors) 1 -}}
 <p>
   <small>
     {{- time.Format (default ":date_long" .Site.Params.dateFormat) .PublishDate -}}
@@ -9,7 +10,7 @@
         <a class="stretched-link position-relative link-muted" href="{{ "/categories/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>
       {{- end }}
     {{- end }}
-    {{- with .Params.contributors -}}
+    {{- with $contributors -}}
       &nbsp;{{ i18n "by" }}&nbsp;
       {{- range $index, $contributor := . -}}
         {{- if gt $index 0 }}{{ if eq $index $last }} and {{ else }}, {{ end }}{{ end -}}

--- a/layouts/_partials/main/blog-meta.html
+++ b/layouts/_partials/main/blog-meta.html
@@ -1,4 +1,4 @@
-{{ $last := sub (len .Params.contributors) 1 -}}
+{{ $last := sub (len (.Params.contributors | slice)) 1 -}}
 <p>
   <small>
     {{- time.Format (default ":date_long" .Site.Params.dateFormat) .PublishDate -}}


### PR DESCRIPTION
## Summary

If contributors are not set in pages it currently produces an error.

## Basic example

See: #107 and thuliteio/doks#1279

## Motivation

This fixes a common issue where contributors can be unset on pages but should be handled as empty.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)
