### PR TITLE
Refactor domain extension assignment in email template

### DIFF
--- a/.changeset/nice-candles-grab.md
+++ b/.changeset/nice-candles-grab.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+Refactor domain extension assignment in email template

--- a/layouts/_partials/main/email.html
+++ b/layouts/_partials/main/email.html
@@ -4,5 +4,5 @@
 {{ $domain := (index $addressParts 1) -}}
 {{ $domainParts := split $domain "." -}}
 {{ $domainName := (index $domainParts 0) -}}
-{{ $domainExtension := (index $domainParts 1) -}}
+{{ $domainExtension := delimit (after 1 $domainParts) "." -}}
 <script nonce="dXNlcj0iaGVsbG8iLGRvbWFpbj0iaGVua3ZlcmxpbmRlLmNvbSIsZG9jdW1lbnQud3JpdGUodXNlcisiQCIrZG9tYWluKTs=">userName="{{ $userName }}",domainName="{{ $domainName  }}",domainExtension="{{ $domainExtension }}",document.write("<a href='mailto:"+userName+"@"+domainName+"."+domainExtension+"'>{{ if ne .emailTitle $address}}{{ .emailTitle | safeHTML }}{{else}}"+userName+"@"+domainName+"."+domainExtension+"{{end}}</a>");</script><noscript>{{ $userName }} at {{ $domainName }} dot {{ $domainExtension  }}</noscript>

--- a/layouts/_partials/main/email.html
+++ b/layouts/_partials/main/email.html
@@ -5,4 +5,5 @@
 {{ $domainParts := split $domain "." -}}
 {{ $domainName := (index $domainParts 0) -}}
 {{ $domainExtension := delimit (after 1 $domainParts) "." -}}
-<script nonce="dXNlcj0iaGVsbG8iLGRvbWFpbj0iaGVua3ZlcmxpbmRlLmNvbSIsZG9jdW1lbnQud3JpdGUodXNlcisiQCIrZG9tYWluKTs=">userName="{{ $userName }}",domainName="{{ $domainName  }}",domainExtension="{{ $domainExtension }}",document.write("<a href='mailto:"+userName+"@"+domainName+"."+domainExtension+"'>{{ if ne .emailTitle $address}}{{ .emailTitle | safeHTML }}{{else}}"+userName+"@"+domainName+"."+domainExtension+"{{end}}</a>");</script><noscript>{{ $userName }} at {{ $domainName }} dot {{ $domainExtension  }}</noscript>
+{{ $domainFull := cond (eq $domainExtension "") $domainName (printf "%s.%s" $domainName $domainExtension) -}}
+<script nonce="dXNlcj0iaGVsbG8iLGRvbWFpbj0iaGVua3ZlcmxpbmRlLmNvbSIsZG9jdW1lbnQud3JpdGUodXNlcisiQCIrZG9tYWluKTs=">userName="{{ $userName }}",domainFull="{{ $domainFull }}",document.write("<a href='mailto:"+userName+"@"+domainFull+"'>{{ if ne .emailTitle $address}}{{ .emailTitle | safeHTML }}{{else}}"+userName+"@"+domainFull+"{{end}}</a>");</script><noscript>{{ $userName }} at {{ $domainName }}{{ if ne $domainExtension "" }} dot {{ $domainExtension }}{{ end }}</noscript>


### PR DESCRIPTION
## Summary

For email addresses with multiple domain e.g. user@university.ac.uk the uk is missing at the end.

## Basic example

Include an email with:

```
[user@university.ac.uk](mailto:user@university.ac.uk)
```
It will produce an email without the uk.

## Motivation

The stops emails from displaying with more than one domain extension.  The alternative is to make sure the ` dot ` is also encapsulated so we could use instead:

```
{{ $address := replace (.emailAddress | safeURL) "mailto:" "" -}}
{{ $addressParts := split $address "@" -}}
{{ $userName := (index $addressParts 0) -}}
{{ $domainName := (index $addressParts 1) -}}
{{ $domainDot := delimit (split $domainName ".") " dot " -}}
<script nonce="dXNlcj0iaGVsbG8iLGRvbWFpbj0iaGVua3ZlcmxpbmRlLmNvbSIsZG9jdW1lbnQud3JpdGUodXNlcisiQCIrZG9tYWluKTs=">userName="{{ $userName }}",domainName="{{ $domainName }}",document.write("<a href='mailto:"+userName+"@"+domainName+"'>{{ if ne .emailTitle $address}}{{ .emailTitle | safeHTML }}{{else}}"+userName+"@"+domainName+"{{end}}</a>");</script><noscript>{{ $userName }} at {{ $domainDot }} </noscript>
```

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)
