### PR TITLE
fix(kroki): lowercase output_format and demote network errors to warnings

### DIFF
--- a/.changeset/great-hotels-perform.md
+++ b/.changeset/great-hotels-perform.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+fix(kroki): lowercase output_format and demote network errors to warnings

--- a/layouts/_markup/render-codeblock-kroki.html
+++ b/layouts/_markup/render-codeblock-kroki.html
@@ -84,15 +84,15 @@ References:
 {{- $attrs = merge $attrs (dict "class" $class "id" $id "alt" "diagram") }}
 
 {{- /* Get diagram. */}}
-{{- $body := dict "diagram_source" $inner "diagram_type" $diagramType "output_format" "SVG" | jsonify }}
+{{- $body := dict "diagram_source" $inner "diagram_type" $diagramType "output_format" "svg" | jsonify }}
 {{- $opts := dict "method" "post" "body" $body }}
 {{- with try (resources.GetRemote $apiEndpoint $opts) }}
   {{- with .Err }}
-    {{- errorf "The %q code block render hook was unable to get the remote diagram. See %s. %s" $renderHookName $position . }}
+    {{- warnf "The %q code block render hook was unable to get the remote diagram. See %s. %s" $renderHookName $position . }}
   {{- else with .Value }}
     {{- $attrs = merge $attrs (dict "src" .RelPermalink) }}
   {{- else }}
-    {{- errorf "The %q code block render hook was unable to get the remote diagram. See %s" $renderHookName $position }}
+    {{- warnf "The %q code block render hook was unable to get the remote diagram. See %s" $renderHookName $position }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary

Two bugs in `layouts/_markup/render-codeblock-kroki.html` that together prevent diagrams from ever rendering and make network failures break the entire build.

## Basic example

**Bug 1 — `output_format: "SVG"` → `"svg"`**

kroki.io returns HTTP 400 for any request that sends an uppercase format string. The correct value per the [Kroki POST API](https://docs.kroki.io/kroki/setup/use-docker-or-podman/#_using_the_post_request) is lowercase `"svg"`. Every user of this template has silently broken diagram rendering.

**Bug 2 — `errorf` → `warnf` on network failure**

A transient network error or a self-hosted Kroki instance being temporarily down aborts the entire Hugo build. A remote service being unreachable is not an authoring error; `warnf` produces a visible warning and lets the build complete.

```diff
-{{- $body := dict "diagram_source" $inner "diagram_type" $diagramType "output_format" "SVG" | jsonify }}
+{{- $body := dict "diagram_source" $inner "diagram_type" $diagramType "output_format" "svg" | jsonify }}
 {{- $opts := dict "method" "post" "body" $body }}
 {{- with try (resources.GetRemote $apiEndpoint $opts) }}
   {{- with .Err }}
-    {{- errorf "The %q code block render hook was unable to get the remote diagram. See %s. %s" $renderHookName $position . }}
+    {{- warnf "The %q code block render hook was unable to get the remote diagram. See %s. %s" $renderHookName $position . }}
   {{- else with .Value }}
     {{- $attrs = merge $attrs (dict "src" .RelPermalink) }}
   {{- else }}
-    {{- errorf "The %q code block render hook was unable to get the remote diagram. See %s" $renderHookName $position }}
+    {{- warnf "The %q code block render hook was unable to get the remote diagram. See %s" $renderHookName $position }}
   {{- end }}
 {{- end }}
```

## Motivation

Bug 1 was reported in issue #106 (Sep 2024) by the maintainer, who also identified the fix in the issue body. The fix was never committed. This PR applies it along with the complementary `errorf` → `warnf` change so that CI pipelines are not broken by intermittent network issues.

Verified locally by overriding the template in a Doks site — diagrams render correctly once `"SVG"` is lowercased.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)

Closes #106