### PR TITLE
feat(header): support menu pre/post labels and external link attributes

### DIFF
--- a/.changeset/dull-friends-joke.md
+++ b/.changeset/dull-friends-joke.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+feat(header): support menu pre/post labels and external link attributes

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -686,3 +686,11 @@ h5.offcanvas-title {
 .navbar > .container-xxl {
     padding-right: 0.75rem;
 }
+
+.nav-link-name-post {
+  margin-left: 0.125rem;
+}
+
+.nav-link-name-pre {
+  margin-right: 0.375rem;
+}

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -127,13 +127,13 @@
                 <ul class="dropdown-menu shadow rounded border-0">
                   {{ range .Children -}}
                   {{- $active = eq .Name $current.Title -}}
-                    <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a></li>
+                    <li><a class="dropdown-item{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}"{{ if and .Params (eq .Params.rel "external") }} target="_blank" rel="noopener noreferrer"{{ end }}{{ if $active }} aria-current="true"{{ end }}>{{ if .Pre }}<span class="nav-link-name-pre">{{ .Pre }}</span>{{ end }}{{ .Name }}{{ if .Post }}<span class="nav-link-name-post">{{ .Post }}</span>{{ end }}</a></li>
                   {{ end -}}
                 </ul>
               </li>
             {{ else -}}
               <li class="nav-item">
-                <a class="nav-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}"{{ if $active }} aria-current="true"{{ end }}>{{ .Name }}</a>
+                <a class="nav-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}"{{ if and .Params (eq .Params.rel "external") }} target="_blank" rel="noopener noreferrer"{{ end }}{{ if $active }} aria-current="true"{{ end }}>{{ if .Pre }}<span class="nav-link-name-pre">{{ .Pre }}</span>{{ end }}{{ .Name }}{{ if .Post }}<span class="nav-link-name-post">{{ .Post }}</span>{{ end }}</a>
               </li>
             {{ end -}}
           {{ end -}}
@@ -275,5 +275,3 @@
 {{ if site.Params.doks.flexSearch -}}
 {{ partial "header/search-modal" . }}
 {{ end -}}
-
-


### PR DESCRIPTION
## Summary

- Render optional menu item `.Pre` and `.Post` content in both top-level and dropdown navigation links
- Add `target="_blank"` and `rel="noopener noreferrer"` for menu items marked as external
- Add header styles for pre/post label spacing in nav links

## Basic example

For example, in `config/_default/menus/menus.en.toml` add:

```toml
[[main]]
  name = "Blog"
  url = "https://thulite.io/blog/"
  weight = 15
  post = '<svg xmlns="http://www.w3.org/2000/svg" class="ms-1 mb-1 icon icon-tabler icon-tabler-external-link" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6" /><path d="M11 13l9 -9" /><path d="M15 4h5v5" /></svg>'
  [[main.params]]
    rel = 'external'

[[main]]
  name = "Community"
  url = "https://github.com/orgs/thuliteio/discussions"
  weight = 20
  post = '<svg xmlns="http://www.w3.org/2000/svg" class="ms-1 mb-1 icon icon-tabler icon-tabler-external-link" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6" /><path d="M11 13l9 -9" /><path d="M15 4h5v5" /></svg>'
  [[main.params]]
    rel = 'external'
```

<img width="715" height="150" alt="2026-04-21_13-46-01" src="https://github.com/user-attachments/assets/e06815c6-1d40-4bd8-a9bf-601d43d88bfd" />

## Motivation

Improve UX main navigation.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)
