### PR TITLE
feat(header): refine dropdown menu styling across themes and mobile

### DIFF
--- a/.changeset/lazy-tires-nail.md
+++ b/.changeset/lazy-tires-nail.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+feat(header): refine dropdown menu styling across themes and mobile

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -687,6 +687,69 @@ h5.offcanvas-title {
     padding-right: 0.75rem;
 }
 
+.dropdown-menu {
+    border: 1px solid var(--sl-color-gray-6) !important;
+    box-shadow: none !important;
+    margin-left: 0.75rem;
+    padding: 0 0.25rem;
+
+    .dropdown-item {
+        margin: 0.25rem 0;
+        padding-left: 0.625rem;
+
+        &:hover,
+        &:focus,
+        &:active {
+            background-color: var(--sl-color-gray-7);
+            border-radius: 0.25rem;
+            color: inherit;
+        }
+
+        &.active {
+            background-color: var(--sl-color-gray-7);
+        }
+    }
+}
+
+@include color-mode(dark) {
+  .dropdown-menu {
+      border: 1px solid var(--sl-color-gray-6) !important;
+      box-shadow: none !important;
+      margin-left: 0.75rem;
+      padding: 0 0.25rem;
+      background-color: var(--sl-color-black);
+
+      .dropdown-item {
+          margin: 0.25rem 0;
+          padding-left: 0.625rem;
+
+          &:hover,
+          &:focus,
+          &:active {
+              background-color: var(--sl-color-gray-6);
+              border-radius: 0.25rem;
+              color: inherit;
+          }
+
+          &.active {
+              background-color: var(--sl-color-gray-6);
+          }
+      }
+  }
+}
+
+@include media-breakpoint-down(lg) {
+  .dropdown-menu {
+    margin-left: 0 !important;
+    padding: 0 0.25rem !important;
+
+  }
+
+  .dropdown:not(#ai-dropdown) .dropdown-menu {
+        border-radius: 0.25rem !important;
+  }
+}
+
 .nav-link-name-post {
   margin-left: 0.125rem;
 }


### PR DESCRIPTION
## Summary

- add consistent dropdown border, spacing, and remove box-shadow
- improve dropdown item hover/focus/active states with subtle rounded highlights
- add dark-mode specific dropdown background and interaction colors
- adjust mobile dropdown spacing and border radius behavior (excluding AI dropdown)

## Basic example

<img width="714" height="310" alt="2026-04-21_14-09-08" src="https://github.com/user-attachments/assets/b3034c1e-c79e-4b7f-b7f9-458b1456c391" />
<img width="713" height="310" alt="2026-04-21_14-09-46" src="https://github.com/user-attachments/assets/776c9697-6b93-47a8-9a5a-24ff34b3e6e5" />

## Motivation

Improve UX main navigation.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)
