### PR TITLE
Add icon support to link-card shortcode

### DIFF
--- a/.changeset/fast-dragons-report.md
+++ b/.changeset/fast-dragons-report.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+Add icon support to link-card shortcode

--- a/layouts/_shortcodes/link-card.html
+++ b/layouts/_shortcodes/link-card.html
@@ -1,5 +1,6 @@
 {{- $opts := dict
   "page" .
+  "src" .Params.src
   "href" .Params.href
   "title" .Params.title
   "description" .Params.description
@@ -20,6 +21,9 @@
   <div class="card text-end w-100{{ with .class}} {{ . }}{{ end }}">
     <div class="card-body d-flex">
       <div class="d-flex flex-column me-auto text-start">
+        {{ with .src }}
+          {{- partial "inline-svg" (dict "page" . "src" . "width" "32px" "class" "svg-inline-custom svg-monochrome text-body-emphasis" ) }}
+        {{ end }}
         <h5 class="card-title my-0"><a href="{{ .href }}"{{ with .target}} target="{{ . }}"{{ end }} class="stretched-link text-reset text-decoration-none"{{ with .rel}} rel="{{ . }}"{{ end }}>{{ .title }}</a></h5>
         {{ with .description }}<p class="card-text mt-1">{{ . }}</p>{{ end }}
       </div>

--- a/layouts/_shortcodes/link-card.html
+++ b/layouts/_shortcodes/link-card.html
@@ -22,7 +22,7 @@
     <div class="card-body d-flex">
       <div class="d-flex flex-column me-auto text-start">
         {{ with .src }}
-          {{- partial "inline-svg" (dict "page" . "src" . "width" "32px" "class" "svg-inline-custom svg-monochrome text-body-emphasis" ) }}
+          {{- partial "inline-svg" (dict "src" . "width" "32px" "class" "svg-inline-custom svg-monochrome text-body-emphasis" ) }}
         {{ end }}
         <h5 class="card-title my-0"><a href="{{ .href }}"{{ with .target}} target="{{ . }}"{{ end }} class="stretched-link text-reset text-decoration-none"{{ with .rel}} rel="{{ . }}"{{ end }}>{{ .title }}</a></h5>
         {{ with .description }}<p class="card-text mt-1">{{ . }}</p>{{ end }}


### PR DESCRIPTION
## Summary

Brief explanation of the proposed changes.

## Basic example

Include a basic example, screenshots, or links.

<img width="648" height="351" alt="2026-05-11_09-47-09" src="https://github.com/user-attachments/assets/868f7c9e-bfb5-4567-ae52-7093e36fd689" />

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)
