### PR TITLE
Render inner Markdown

### DIFF
--- a/.changeset/ninety-balloons-laugh.md
+++ b/.changeset/ninety-balloons-laugh.md
@@ -1,0 +1,5 @@
+---
+"@thulite/doks-core": patch
+---
+
+Render inner Markdown

--- a/layouts/_shortcodes/preview.html
+++ b/layouts/_shortcodes/preview.html
@@ -2,7 +2,7 @@
   <div class="preview">
     <figcaption>Preview</figcaption>
     <div class="preview-content">
-      {{ .Inner | markdownify }}
+      {{ .Page.RenderString (dict "display" "block") .Inner }}
     </div>
   </div>
 </figure>

--- a/layouts/_shortcodes/preview.html
+++ b/layouts/_shortcodes/preview.html
@@ -2,7 +2,7 @@
   <div class="preview">
     <figcaption>Preview</figcaption>
     <div class="preview-content">
-      {{ .Inner }}
+      {{ .Inner | markdownify }}
     </div>
   </div>
 </figure>


### PR DESCRIPTION
## Summary

Brief explanation of the proposed changes.

```html
<figure class="preview-figure">
  <div class="preview">
    <figcaption>Preview</figcaption>
    <div class="preview-content">
      {{ .Inner | markdownify }}
    </div>
  </div>
</figure>
```

## Basic example

Include a basic example, screenshots, or links.
<img width="647" height="268" alt="2026-05-12_14-10-11" src="https://github.com/user-attachments/assets/e372d125-1a2a-447f-8daf-45ccc59e8721" />

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test` (if relevant)
